### PR TITLE
Hotfix/master-summary-css-&-urls

### DIFF
--- a/application/templates/declaration-summary.html
+++ b/application/templates/declaration-summary.html
@@ -510,7 +510,7 @@
                 {{dbs_certificate_number}}
             </td>
             <td class="change-answer">
-                <a href="{{ URL_PREFIX }}/dbs-check/dbs-details?id={{application_id}}#id_dbs_certificate_number"
+                <a href="{{ URL_PREFIX }}/criminal-record/your-details/?id={{application_id}}#id_dbs_certificate_number"
                    alt='Update your DBS certificate number'>
                     Change <span class="visuallyhidden">DBS certificate number</span>
                 </a>
@@ -530,7 +530,7 @@
             </td>
             {% endif %}
             <td class="change-answer">
-                <a href="{{ URL_PREFIX }}/dbs-check/dbs-details?id={{application_id}}"
+                <a href="{{ URL_PREFIX }}criminal-record/your-details/?id={{application_id}}"
                    alt='Update whether you have any cautions or convictions?'>
                     Change <span class="visuallyhidden">do you have any cautions or convictions?</span>
                 </a>
@@ -551,7 +551,7 @@
             </td>
             {% endif %}
             <td class="change-answer">
-                <a href="{{ URL_PREFIX }}/dbs-check/upload-dbs?id={{application_id}}#id_declaration"
+                <a href="{{ URL_PREFIX }}/criminal-record/post-certificate/?id={{application_id}}#id_declaration"
                    alt='Update whether you will send your DBS certificate to Ofsted?'>
                     Change <span class="visuallyhidden">will you send your DBS certificate to Ofsted?</span>
                 </a>

--- a/application/templates/declaration-summary.html
+++ b/application/templates/declaration-summary.html
@@ -18,6 +18,11 @@
         </h1>
     </div>
     <table class="check-your-answers form-group grid-row">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -70,6 +75,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup> 
         <thead>
         <tr>
             <th colspan="3">
@@ -185,6 +195,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -391,6 +406,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -492,6 +512,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row" style="table-layout: fixed; width: 100%">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -561,6 +586,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -593,6 +623,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row" style="table-layout: fixed; width: 100%">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -730,6 +765,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row" style="table-layout: fixed; width: 100%">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -867,6 +907,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row" style="table-layout: fixed; width: 100%">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -900,6 +945,11 @@
         </tbody>
     </table>
     <table class="check-your-answers form-group grid-row" style="table-layout: fixed; width: 100%">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -934,6 +984,11 @@
     </table>
     {% for name, day, month, year, relationship, dbs_certificate_number, permission in adult_lists %}
     <table class="check-your-answers form-group grid-row">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">
@@ -1071,6 +1126,11 @@
     {% endfor %}
     {% for name, day, month, year, relationship in child_lists %}
     <table class="check-your-answers form-group grid-row">
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:40%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
         <tr>
             <th colspan="3">

--- a/application/templates/declaration-summary.html
+++ b/application/templates/declaration-summary.html
@@ -530,7 +530,7 @@
             </td>
             {% endif %}
             <td class="change-answer">
-                <a href="{{ URL_PREFIX }}criminal-record/your-details/?id={{application_id}}"
+                <a href="{{ URL_PREFIX }}/criminal-record/your-details/?id={{application_id}}"
                    alt='Update whether you have any cautions or convictions?'>
                     Change <span class="visuallyhidden">do you have any cautions or convictions?</span>
                 </a>


### PR DESCRIPTION
Things to check:

- [x] Clicking on change for all fields under 'Criminal Record Check' on the master summary page brings you to working URLs

- [x] All tables now have the same column format of 40% 40% 20%