### PR TITLE
feat/generic-template-refactoring

### DIFF
--- a/application/forms.py
+++ b/application/forms.py
@@ -1288,8 +1288,10 @@ class DBSCheckSummaryForm(ChildminderForms):
     GOV.UK form for the Your criminal record (DBS) check: summary page
     """
     field_label_classes = 'form-label-bold'
-    error_summary_template_name = 'error-summary.html'
+    error_summary_template_name = 'generic-error-summary.html'
     auto_replace_widgets = True
+
+    arc_errors = forms.CharField()
 
 
 class HealthIntroForm(ChildminderForms):

--- a/application/summary_page_data.py
+++ b/application/summary_page_data.py
@@ -99,3 +99,18 @@ second_reference_link_dict = {'full_name': 'References-Second-Reference-View',
                               'phone_number': 'References-Second-Reference-Contact-Details-View',
                               'email_address': 'References-Second-Reference-Contact-Details-View'}
 
+submit_link_dict = {'login_details': 'Contact-Email-View',
+                    'personal_details': 'Personal-Details-Guidance-View',
+                    'first_aid_training': 'First-Aid-Training-Guidance-View',
+                    'criminal_record_check': 'DBS-Check-Guidance-View',
+                    'health': 'Health-Intro-View',
+                    'references': 'References-Intro-View',
+                    'people_in_home': 'Other-People-Guidance-View'}
+
+back_link_dict = {'login_details': 'Question-View',
+                  'personal_details': 'Personal-Details-Guidance-View',
+                  'first_aid_training': 'First-Aid-Training-Guidance-View',
+                  'criminal_record_check': 'DBS-Check-Guidance-View',
+                  'health': 'Health-Intro-View',
+                  'references': 'References-Intro-View',
+                  'people_in_home': 'Other-People-Guidance-View'}

--- a/application/summary_page_data.py
+++ b/application/summary_page_data.py
@@ -73,7 +73,7 @@ other_adult_summary_link_dict = {'adults_in_home': 'Other-People-Adult-Question-
 other_child_summary_name_dict = {'children_in_home': 'Do you live with any children'}
 other_child_summary_link_dict = {'children_in_home': 'Other-People-Children-Question-View'}
 
-first_reference_name_dict = {'full_name': 'Full_name',
+first_reference_name_dict = {'full_name': 'Full name',
                              'relationship': 'How they know you',
                              'known_for': 'Known for',
                              'address': 'Address',
@@ -86,7 +86,7 @@ first_reference_link_dict = {'full_name': 'References-First-Reference-View',
                              'phone_number': 'References-First-Reference-Contact-Details-View',
                              'email_address': 'References-First-Reference-Contact-Details-View'}
 
-second_reference_name_dict = {'full_name': 'Full_name',
+second_reference_name_dict = {'full_name': 'Full name',
                               'relationship': 'How they know you',
                               'known_for': 'Known for',
                               'address': 'Address',

--- a/application/summary_page_data.py
+++ b/application/summary_page_data.py
@@ -9,11 +9,17 @@ dbs_summary_dict = {'data_names': ['dbs_certificate_number', 'cautions_convictio
                     'page_title': 'Check your answers: criminal record (DBS) check'
                     }
 
+###
+
+# Name dict contains the data_name of each table field and the actual name to be rendered
+
 contact_info_name_dict = {'email': 'Your email',
                            'mobile_number': 'Mobile phone number',
                            'add_phone_number': 'Alternative phone number',
                            'security_question': 'Knowledge based question',
                            'security_answer': 'Knowledge based answer'}
+
+# Link dict contains the data_name of each table field and the name of the change_link view to be reversed in template
 
 contact_info_link_dict = {'email': 'Contact-Email-View',
                            'mobile_number': 'Contact-Phone-View',
@@ -21,7 +27,9 @@ contact_info_link_dict = {'email': 'Contact-Email-View',
                            'security_question': 'Question-View',
                            'security_answer': 'Question-View'}
 
-personal_details_name_dict = {'name':'Your name',
+###
+
+personal_details_name_dict = {'name': 'Your name',
                               'date_of_birth': 'Your date of birth',
                               'home_address': 'Home address',
                               'childcare_location': 'Childcare location'}
@@ -30,6 +38,8 @@ personal_details_link_dict = {'name': 'Personal-Details-Name-View',
                               'date_of_birth': 'Personal-Details-DOB-View',
                               'home_address': 'Personal-Details-Home-Address-Manual-View',
                               'childcare_location': 'Personal-Details-Location-Of-Care-View'}
+
+###
 
 first_aid_name_dict = {'first_aid_training_organisation': 'Training organisation',
                        'title_of_training_course': 'Title of training course',
@@ -43,9 +53,13 @@ first_aid_link_dict = {'first_aid_training_organisation': 'First-Aid-Training-De
                        'renew_certificate': 'First-Aid-Training-Renew-View',
                        'show_certificate': 'First-Aid-Training-Declaration-View'}
 
+###
+
 health_name_dict = {'health_submission_consent': 'Will you submit a health declaration booklet to Ofsted'}
 
 health_link_dict = {'health_submission_consent': 'Health-Booklet-View'}
+
+###
 
 other_adult_name_dict = {'full_name': 'Name',
                          'date_of_birth': 'Date of birth',
@@ -59,6 +73,8 @@ other_adult_link_dict = {'full_name': 'Other-People-Adult-Details-View',
                          'dbs_certificate_number': 'Other-People-Adult-DBS-View',
                          'permission': 'Other-People-Adult-Permission-View'}
 
+###
+
 other_child_name_dict = {'full_name': 'Name',
                          'date_of_birth': 'Date of birth',
                          'relationship': 'Relationship'}
@@ -67,11 +83,16 @@ other_child_link_dict = {'full_name': 'Other-People-Children-Details-View',
                          'date_of_birth': 'Other-People-Children-Details-View',
                          'relationship': 'Other-People-Children-Details-View'}
 
+# The below dictionaries are for the two tables at the top of the other people summary page
+
 other_adult_summary_name_dict = {'adults_in_home': 'Do you live with anyone who is 16 or over'}
 other_adult_summary_link_dict = {'adults_in_home': 'Other-People-Adult-Question-View'}
 
+
 other_child_summary_name_dict = {'children_in_home': 'Do you live with any children'}
 other_child_summary_link_dict = {'children_in_home': 'Other-People-Children-Question-View'}
+
+###
 
 first_reference_name_dict = {'full_name': 'Full name',
                              'relationship': 'How they know you',
@@ -99,6 +120,11 @@ second_reference_link_dict = {'full_name': 'References-Second-Reference-View',
                               'phone_number': 'References-Second-Reference-Contact-Details-View',
                               'email_address': 'References-Second-Reference-Contact-Details-View'}
 
+###
+
+# This dictionary contains the view to be reversed if the user clicks submit on the summary page ONLY if there are
+# errors to be rectified
+
 submit_link_dict = {'login_details': 'Contact-Email-View',
                     'personal_details': 'Personal-Details-Guidance-View',
                     'first_aid_training': 'First-Aid-Training-Guidance-View',
@@ -106,6 +132,8 @@ submit_link_dict = {'login_details': 'Contact-Email-View',
                     'health': 'Health-Intro-View',
                     'references': 'References-Intro-View',
                     'people_in_home': 'Other-People-Guidance-View'}
+
+
 
 back_link_dict = {'login_details': 'Question-View',
                   'personal_details': 'Personal-Details-Guidance-View',

--- a/application/summary_page_data.py
+++ b/application/summary_page_data.py
@@ -1,0 +1,101 @@
+dbs_summary_dict = {'data_names': ['dbs_certificate_number', 'cautions_convictions', 'send_certificate_declare'],
+                    'display_names': ['DBS certificate number', 'Do you have any cautions or convictions?',
+                                      'Will you send your DBS certificate to Ofsted?'],
+                    'back_url_names': ['DBS-Check-DBS-Details-View',
+                                       'DBS-Check-DBS-Details-View',
+                                       'DBS-Check-Upload-DBS-View'],
+                    'table_names': ['Check your answers: your criminal record check'],
+                    'table_error_names': ['There was a problem with your criminal record check'],
+                    'page_title': 'Check your answers: criminal record (DBS) check'
+                    }
+
+contact_info_name_dict = {'email': 'Your email',
+                           'mobile_number': 'Mobile phone number',
+                           'add_phone_number': 'Alternative phone number',
+                           'security_question': 'Knowledge based question',
+                           'security_answer': 'Knowledge based answer'}
+
+contact_info_link_dict = {'email': 'Contact-Email-View',
+                           'mobile_number': 'Contact-Phone-View',
+                           'add_phone_number': 'Contact-Phone-View',
+                           'security_question': 'Question-View',
+                           'security_answer': 'Question-View'}
+
+personal_details_name_dict = {'name':'Your name',
+                              'date_of_birth': 'Your date of birth',
+                              'home_address': 'Home address',
+                              'childcare_location': 'Childcare location'}
+
+personal_details_link_dict = {'name': 'Personal-Details-Name-View',
+                              'date_of_birth': 'Personal-Details-DOB-View',
+                              'home_address': 'Personal-Details-Home-Address-Manual-View',
+                              'childcare_location': 'Personal-Details-Location-Of-Care-View'}
+
+first_aid_name_dict = {'first_aid_training_organisation': 'Training organisation',
+                       'title_of_training_course': 'Title of training course',
+                       'course_date': 'Date you completed your course',
+                       'renew_certificate': 'Will you renew your certificate in the next few months?',
+                       'show_certificate': 'Will you show a copy of your certificate to an inspector?'}
+
+first_aid_link_dict = {'first_aid_training_organisation': 'First-Aid-Training-Details-View',
+                       'title_of_training_course': 'First-Aid-Training-Details-View',
+                       'course_date': 'First-Aid-Training-Details-View',
+                       'renew_certificate': 'First-Aid-Training-Renew-View',
+                       'show_certificate': 'First-Aid-Training-Declaration-View'}
+
+health_name_dict = {'health_submission_consent': 'Will you submit a health declaration booklet to Ofsted'}
+
+health_link_dict = {'health_submission_consent': 'Health-Booklet-View'}
+
+other_adult_name_dict = {'full_name': 'Name',
+                         'date_of_birth': 'Date of birth',
+                         'relationship': 'Relationship',
+                         'dbs_certificate_number': 'DBS certificate number',
+                         'permission': 'Permission for checks'}
+
+other_adult_link_dict = {'full_name': 'Other-People-Adult-Details-View',
+                         'date_of_birth': 'Other-People-Adult-Details-View',
+                         'relationship': 'Other-People-Adult-Details-View',
+                         'dbs_certificate_number': 'Other-People-Adult-DBS-View',
+                         'permission': 'Other-People-Adult-Permission-View'}
+
+other_child_name_dict = {'full_name': 'Name',
+                         'date_of_birth': 'Date of birth',
+                         'relationship': 'Relationship'}
+
+other_child_link_dict = {'full_name': 'Other-People-Children-Details-View',
+                         'date_of_birth': 'Other-People-Children-Details-View',
+                         'relationship': 'Other-People-Children-Details-View'}
+
+other_adult_summary_name_dict = {'adults_in_home': 'Do you live with anyone who is 16 or over'}
+other_adult_summary_link_dict = {'adults_in_home': 'Other-People-Adult-Question-View'}
+
+other_child_summary_name_dict = {'children_in_home': 'Do you live with any children'}
+other_child_summary_link_dict = {'children_in_home': 'Other-People-Children-Question-View'}
+
+first_reference_name_dict = {'full_name': 'Full_name',
+                             'relationship': 'How they know you',
+                             'known_for': 'Known for',
+                             'address': 'Address',
+                             'phone_number': 'Phone number',
+                             'email_address': 'Email address'}
+first_reference_link_dict = {'full_name': 'References-First-Reference-View',
+                             'relationship': 'References-First-Reference-View',
+                             'known_for': 'References-First-Reference-View',
+                             'address': 'References-Enter-First-Reference-Address-View',
+                             'phone_number': 'References-First-Reference-Contact-Details-View',
+                             'email_address': 'References-First-Reference-Contact-Details-View'}
+
+second_reference_name_dict = {'full_name': 'Full_name',
+                              'relationship': 'How they know you',
+                              'known_for': 'Known for',
+                              'address': 'Address',
+                              'phone_number': 'Phone number',
+                              'email_address': 'Email address'}
+second_reference_link_dict = {'full_name': 'References-Second-Reference-View',
+                              'relationship': 'References-Second-Reference-View',
+                              'known_for': 'References-Second-Reference-View',
+                              'address': 'References-Enter-Second-Reference-Address-View',
+                              'phone_number': 'References-Second-Reference-Contact-Details-View',
+                              'email_address': 'References-Second-Reference-Contact-Details-View'}
+

--- a/application/table_util.py
+++ b/application/table_util.py
@@ -2,8 +2,14 @@ from .models import ArcComments
 
 
 class Table:
-
+    """
+    Table data structure use in generic summary template, this is used as a container for the list of rows with values
+    """
     def get_errors(self):
+        """
+        Method to scan each row in a table for any occurrences in the ARC_COMMENTS table (i.e it has an error)
+        :return: Does not need to return anything as it edits the rows in its row list
+        """
         for row in self.row_list:
             for key in self.table_pk:
                 if ArcComments.objects.filter(table_pk=key, field_name=row.data_name).count() == 1:
@@ -17,12 +23,25 @@ class Table:
                         pass
 
     def add_row(self, row):
+        """
+        A method to add a row to a tables row list
+        :param row: The new row object
+        :return:
+        """
         self.row_list.append(row)
 
     def get_row_list(self):
+        """
+        Standar get method for row list
+        :return:
+        """
         return self.row_list
 
     def get_error_amount(self):
+        """
+        Method to collect the amount of errors that have occurred in a table
+        :return: Returns the amount of errors contained in thw rowlist
+        """
         error_count = 0
         for row in self.row_list:
             if row.error != '':
@@ -30,14 +49,29 @@ class Table:
         return error_count
 
     def __init__(self, table_pk):
+        """
+        Standard init for attributes used in other methods
+        :param table_pk: The primary key of the database table from which the row list is made (this can be multiple)
+        """
         self.row_list = []
         self.title = ''
         self.table_pk = table_pk
 
 
 class Row:
+    """
+    Class to contain a specific row rendered in a table on the generic summary template
+    """
 
     def __init__(self, data_name, row_name, value, back_link, error):
+        """
+        Standard init for all necessary fields
+        :param data_name: The name of the field as stored in the database
+        :param row_name: The name of the field as rendered on the template
+        :param value: The value of the field
+        :param back_link: The view which, when reversed, redirects to the page where the value is defined
+        :param error: The error associated with the field, empty by default, only populated on table.get_errors
+        """
 
         self.data_name = data_name
         self.row_name = row_name
@@ -77,16 +111,31 @@ def field_mapper(data_object, field_names, data_dictionary={}):
     return data_dictionary
 
 
-def multi_table_magic(tables_values, page_name_dict, page_link_dict):
+def create_tables(tables_values, page_name_dict, page_link_dict):
+    """
+    Function to create a list of table objects
+    :param tables_values: A list of dictionaries containing all the details of the  tables to be rendered on the page
+    :param page_name_dict: The dictionary containing the data name for each of the fields linked to the name to be
+    rendered on the page
+    :param page_link_dict: The dictionary containing the data name for each of the fields linked to the change link
+    where the data was defined
+    :return: Returns the full list of table objects in a form that can be passed to the generic summary template
+    """
     table_output_list = []
     for table in tables_values:
 
+        # Each iteration of table will be a dictionary (see a call of this funciton for the definition of this)
         for key, value in table['fields'].items():
+            # Create a row object as defined above, using the data name as the key
             temp_row = Row(key, page_name_dict[key], value, page_link_dict[key], '')
+            # The actual table object is passed into the function without rows, the row is added here
             table['table_object'].add_row(temp_row)
+
+        # Once all rows have been addded to the object, get errors can be called, getting any errors for all of the rows
         table['table_object'].get_errors()
         table['table_object'].title = table['title']
         table['table_object'].error_summary_title = table['error_summary_title']
+        # An extra part to the back links must be added for the other people pages, if this detail is passed, its added
         if 'other_people_numbers' in table.keys():
             table['table_object'].other_people_numbers = table['other_people_numbers']
         table_output_list.append(table['table_object'])

--- a/application/table_util.py
+++ b/application/table_util.py
@@ -1,5 +1,7 @@
-from .models import ArcComments
+from django.urls import reverse
 
+from .models import ArcComments, Application
+from .summary_page_data import submit_link_dict, back_link_dict
 
 class Table:
     """
@@ -12,7 +14,7 @@ class Table:
         """
         for row in self.row_list:
             for key in self.table_pk:
-                if ArcComments.objects.filter(table_pk=key, field_name=row.data_name).count() == 1:
+                if ArcComments.objects.filter(table_pk=key, field_name=row.data_name, flagged=True).count() == 1:
                     log = ArcComments.objects.get(table_pk=key, field_name=row.data_name)
                     try:
                         if log.flagged:
@@ -140,3 +142,20 @@ def create_tables(tables_values, page_name_dict, page_link_dict):
             table['table_object'].other_people_numbers = table['other_people_numbers']
         table_output_list.append(table['table_object'])
     return table_output_list
+
+
+def submit_link_setter(variables, table_list, section_name, application_id):
+    application = Application.objects.get(application_id=application_id)
+    for table in table_list:
+        if table.get_error_amount() != 0:
+            variables['submit_link'] = reverse(submit_link_dict[section_name])
+        else:
+            #Go to task list
+            variables['submit_link'] = reverse('morebeta')
+        #If section status is completed and not in arc review, we should go back to the previous question in section
+        if application.application_status != 'FURTHER_INFORMATION':
+            variables['back_link'] = back_link_dict[section_name]
+        # Otherwise, return to the task list
+        else:
+            variables['back_link'] = 'morebeta'
+    return variables

--- a/application/table_util.py
+++ b/application/table_util.py
@@ -1,0 +1,61 @@
+from .models import ArcComments
+
+
+class Table:
+
+    def get_errors(self):
+        for row in self.row_list:
+            if ArcComments.objects.filter(table_pk=self.table_pk, field_name=row.data_name).count() == 1:
+                log = ArcComments.objects.get(table_pk=self.table_pk, field_name=row.data_name)
+                try:
+                    if log.flagged:
+                        row.error = log.comment
+                    else:
+                        row.error = ''
+                except:
+                    pass
+
+    def add_row(self, row):
+        self.row_list.append(row)
+
+    def get_row_list(self):
+        return self.row_list
+
+    def __init__(self, table_pk):
+        self.row_list = []
+        self.title = ''
+        self.table_pk = table_pk
+
+
+class Row:
+
+    def __init__(self, data_name, row_name, value, back_link, error):
+
+        self.data_name = data_name
+        self.row_name = row_name
+        self.value = value
+        self.back_link = back_link
+        self.error = error
+
+def table_creator(object_list, field_names, data_names):
+    data_list = []
+    table_list = []
+    for object in object_list:
+        field_dict = field_mapper(object, data_names)
+        for name in data_names:
+            data_list.append(field_dict[name])
+        row_data = zip(data_names,field_names, data_list)
+        temp_table = Table(object.pk)
+        for row in row_data:
+            local_row = Row(row[0], row[1], row[2], '', '')
+            temp_table.add_row(local_row)
+        temp_table.get_errors()
+        table_list.append(temp_table)
+    return(table_list)
+
+
+def field_mapper(data_object, field_names, data_dictionary={}):
+    for field in data_object._meta.get_fields():
+        if field.name in field_names:
+            data_dictionary[field.name] = getattr(data_object, field.name)
+    return data_dictionary

--- a/application/table_util.py
+++ b/application/table_util.py
@@ -21,6 +21,13 @@ class Table:
     def get_row_list(self):
         return self.row_list
 
+    def get_error_amount(self):
+        error_count = 0
+        for row in self.row_list:
+            if row.error != '':
+                error_count = error_count + 1
+        return error_count
+
     def __init__(self, table_pk):
         self.row_list = []
         self.title = ''
@@ -37,21 +44,27 @@ class Row:
         self.back_link = back_link
         self.error = error
 
-def table_creator(object_list, field_names, data_names):
+
+def table_creator(object_list, field_names, data_names, table_names, table_error_names, back_url_names):
+
     data_list = []
     table_list = []
     for object in object_list:
         field_dict = field_mapper(object, data_names)
         for name in data_names:
             data_list.append(field_dict[name])
-        row_data = zip(data_names,field_names, data_list)
+        row_data = zip(data_names,field_names, data_list, back_url_names)
         temp_table = Table(object.pk)
         for row in row_data:
-            local_row = Row(row[0], row[1], row[2], '', '')
+            local_row = Row(row[0], row[1], row[2], row[3], '')
             temp_table.add_row(local_row)
         temp_table.get_errors()
         table_list.append(temp_table)
-    return(table_list)
+    table_to_title = zip(table_list, table_names, table_error_names)
+    for table, name, error_name in table_to_title:
+        table.title = name
+        table.error_summary_title = error_name
+    return table_list
 
 
 def field_mapper(data_object, field_names, data_dictionary={}):

--- a/application/templates/awaiting-review.html
+++ b/application/templates/awaiting-review.html
@@ -7,9 +7,15 @@
 
 <div class="column-full">
     <div class="grid-row">
-        <h1 class="form-title heading-large">
-            Awaiting Review
-        </h1>
+        {% if resubmitted == '1' %}
+            <h1 class="form-title heading-large">
+                Thank you for resubmitting your application
+            </h1>
+        {% else %}
+            <h1 class="form-title heading-large">
+                Awaiting review
+            </h1>
+        {% endif %}
         <p>Application actions are on Ofsted</p>
     </div>
 </div>

--- a/application/templates/dbs-check-summary.html
+++ b/application/templates/dbs-check-summary.html
@@ -27,7 +27,7 @@
         <tbody>
         <tr>
             <td style="word-wrap: break-word" class=summary-column>
-                DBS certificate number
+
             </td>
             <td style="word-wrap: break-word" class=summary-column>
                 {{dbs_certificate_number}}
@@ -41,7 +41,7 @@
         </tr>
         <tr>
             <td style="word-wrap: break-word" class=summary-column>
-                Do you have any cautions or convictions?
+
             </td>
             {% if cautions_convictions is True %}
             <td style="word-wrap: break-word" class=summary-column>
@@ -62,7 +62,7 @@
         {% if cautions_convictions is True %}
         <tr>
             <td style="word-wrap: break-word" class=summary-column>
-                Will you send your DBS certificate to Ofsted?
+
             </td>
             {% if declaration is True %}
             <td style="word-wrap: break-word" class=summary-column>

--- a/application/templates/generic-error-summary.html
+++ b/application/templates/generic-error-summary.html
@@ -5,17 +5,21 @@
       {{ table.error_summary_title }}
     </h2>
     <ul class="error-summary-list">
-
+    {% with other_people_numbers=table.other_people_numbers %}
       <p>Please review the following errors: </p>
 
       {% for row in table.row_list %}
         <li class="field-error">
           <ul>
-              <a href="#{{ row.data_name }}">{{ row.error }}</a>
+
+              <a href="{% url row.back_link %}?id={{application_id}}{{other_people_numbers}}">{{ row.error }}</a>
           </ul>
 
         </li>
+
       {% endfor %}
+
+      {% endwith %}
     </ul>
   </div>
 {% endif %}

--- a/application/templates/generic-error-summary.html
+++ b/application/templates/generic-error-summary.html
@@ -1,0 +1,22 @@
+{% for table in table_list %}
+{% if table.get_error_amount != 0 %}
+  <div class="error-summary" aria-labelledby="error-summary-heading-{{ random_string }}" role="alert" tabindex="-1">
+    <h2 class="heading-medium error-summary-heading" id="error-summary-heading-{{ random_string }}">
+      {{ table.error_summary_title }}
+    </h2>
+    <ul class="error-summary-list">
+
+      <p>Please review the following errors: </p>
+
+      {% for row in table.row_list %}
+        <li class="field-error">
+          <ul>
+              <a href="#{{ row.data_name }}">{{ row.error }}</a>
+          </ul>
+
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}
+{% endfor %}

--- a/application/templates/generic-summary-template.html
+++ b/application/templates/generic-summary-template.html
@@ -1,0 +1,80 @@
+{% extends 'govuk_template.html' %}
+{% block page_title %}{{page_title}}{% endblock %}
+{% load static %}
+{% load govuk_template_base %}
+
+{% block inner_content %}
+
+<div class="column-full">
+        {% include "generic-error-summary.html" with table_list=table_list %}
+
+    <div class="grid-row">
+        <h1 class="form-title heading-large">{{ page_title }}</h1>
+    </div>
+    {% for table in table_list %}
+    <table class="check-your-answers form-group grid-row" style="table-layout: fixed; width: 100%">
+        <colgroup>
+            <col class="summary-column">
+            <col class="summary-column">
+            <col class="change-answer">
+        </colgroup>
+        <thead>
+        <tr>
+        <th colspan="3">
+                <div class="heading-medium">
+                    {{ table.title }}
+                </div>
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for row in table.row_list %}
+        {% if row.error != '' %}
+        <tr>
+            <td class="error-row" colspan="3">
+                <p class="error-container">
+                <i class="icon icon-important icon-ofsted-download">
+                    <span class="visually-hidden">Warning</span>
+                </i>
+                <strong class="bold-small error-text">
+                    {{ row.error }}
+                </strong>
+                </p>
+            </td>
+        </tr>
+        {% endif %}
+        {% if row.value != None %}
+        <tr id="{{row.data_name}}">
+            {% if row.error != '' %}
+            <td class="summary-column error-row">
+                {% else %}
+                <td class=summary-column>
+            {% endif %}
+                {{row.row_name}}
+            </td>
+            <td class=summary-column>
+                {{row.value}}
+            </td>
+            <td class="change-answer">
+                <a href="{% url row.back_link %}?id={{application_id}}#id_{{row.data_name}}-group"
+                   alt='Change DBS certificate number'>
+                    Change <span class="visuallyhidden">DBS certificate number</span>
+                </a>
+            </td>
+        </tr>
+        {% endif %}
+        {% endfor %}
+        </tbody>
+    </table>
+
+    {% endfor %}
+    <br>
+    <div class="form-group grid-row">
+        <form action="{{ URL_PREFIX}}/task-list?id={{application_id}}" method="get">
+            <input type="submit" class="button" value="Confirm and continue"/>
+            <input type="hidden" value="{{application_id}}" name="id"/>
+        </form>
+    </div>
+    <br>
+</div>
+        {% endblock %}

--- a/application/templates/generic-summary-template.html
+++ b/application/templates/generic-summary-template.html
@@ -6,7 +6,15 @@
 {% block inner_content %}
 
 <div class="column-full">
-        {% include "generic-error-summary.html" with table_list=table_list %}
+    <div class="grid-row">
+        <!-- Back button -->
+        <a href="{% url back_link %}?id={{ application_id }}" class="link-back"
+           style="margin-right: 10px; line-height: 28px" alt='Back to application list'>
+            Back
+        </a>
+    </div>
+
+        {% include "generic-error-summary.html" with table_list=table_list application_id=application_id %}
 
     <div class="grid-row">
         <h1 class="form-title heading-large">{{ page_title }}</h1>
@@ -70,10 +78,13 @@
     {% endfor %}
     <br>
     <div class="form-group grid-row">
-        <form action="{{ URL_PREFIX}}{{ submit_link|default:"/task-list"}}?id={{application_id}}" method="get">
+        <form action="{{ submit_link|default:"/task-list/"}}?id={{application_id}}" method="get">
             <input type="submit" class="button" value="Confirm and continue"/>
             <input type="hidden" value="{{application_id}}" name="id"/>
         </form>
+    </div>
+    <div class="form-group grid-row">
+        <a href="{{ URL_PREFIX }}/task-list?id={{application_id}}">Return to list</a>
     </div>
     <br>
 </div>

--- a/application/templates/generic-summary-template.html
+++ b/application/templates/generic-summary-template.html
@@ -56,7 +56,7 @@
                 {{row.value}}
             </td>
             <td class="change-answer">
-                <a href="{% url row.back_link %}?id={{application_id}}#id_{{row.data_name}}-group"
+                <a href="{% url row.back_link %}?id={{application_id}}{{table.other_people_numbers}}#id_{{row.data_name}}-group"
                    alt='Change DBS certificate number'>
                     Change <span class="visuallyhidden">DBS certificate number</span>
                 </a>
@@ -70,7 +70,7 @@
     {% endfor %}
     <br>
     <div class="form-group grid-row">
-        <form action="{{ URL_PREFIX}}/task-list?id={{application_id}}" method="get">
+        <form action="{{ URL_PREFIX}}{{ submit_link|default:"/task-list"}}?id={{application_id}}" method="get">
             <input type="submit" class="button" value="Confirm and continue"/>
             <input type="hidden" value="{{application_id}}" name="id"/>
         </form>

--- a/application/views/base.py
+++ b/application/views/base.py
@@ -9,6 +9,8 @@ import logging
 
 from django.shortcuts import render
 
+from .. import status
+
 # initiate logging
 log = logging.getLogger('django.server')
 
@@ -49,7 +51,11 @@ def awaiting_review(request):
     :return: an HttpResponse object with the rendered awaiting review saved template
     """
     application_id_local = request.GET["id"]
+    resubmitted = request.GET["resubmitted"]
+    if resubmitted == '1':
+        status.update(application_id_local, 'application_status', 'SUBMITTED')
     variables = {
+        'resubmitted': resubmitted,
         'application_id': application_id_local
     }
     return render(request, 'awaiting-review.html', variables)

--- a/application/views/base.py
+++ b/application/views/base.py
@@ -51,7 +51,10 @@ def awaiting_review(request):
     :return: an HttpResponse object with the rendered awaiting review saved template
     """
     application_id_local = request.GET["id"]
-    resubmitted = request.GET["resubmitted"]
+    if 'resubmitted' in request.GET.keys():
+        resubmitted = request.GET["resubmitted"]
+    else:
+        resubmitted = '0'
     if resubmitted == '1':
         status.update(application_id_local, 'application_status', 'SUBMITTED')
     variables = {

--- a/application/views/contact_info.py
+++ b/application/views/contact_info.py
@@ -13,6 +13,8 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
+from .. table_util import multi_table_magic, Table
+from ..summary_page_data import contact_info_link_dict, contact_info_name_dict
 from .. import magic_link, status
 from ..business_logic import login_contact_logic, reset_declaration, login_contact_logic_phone
 from ..forms import ContactEmailForm, ContactPhoneForm, ContactSummaryForm
@@ -177,20 +179,32 @@ def contact_summary(request):
         if application.login_details_status != 'COMPLETED':
             status.update(app_id, 'login_details_status', 'COMPLETED')
 
-        form = ContactSummaryForm()
-        variables = {
-            'form': form,
-            'application_id': app_id,
+        contact_info_fields = {
             'email': email,
             'mobile_number': mobile_number,
             'add_phone_number': add_phone_number,
             'security_question': security_question,
             'security_answer': security_answer,
+        }
+
+        contact_info_table = {'table_object': Table([user_details.pk]),
+                              'fields': contact_info_fields,
+                              'title': 'Your login details',
+                              'error_summary_title': 'There is something wrong with your login details'}
+        table_list = multi_table_magic([contact_info_table], contact_info_name_dict, contact_info_link_dict)
+
+        form = ContactSummaryForm()
+        variables = {
+            'form': form,
+            'application_id': app_id,
+            'table_list': table_list,
+            'page_title': 'Check your answers: your login details',
+            'submit_link': '/childcare/guidance/',
             'login_details_status': application.login_details_status,
             'childcare_type_status': application.childcare_type_status
         }
 
-        return render(request, 'contact-summary.html', variables)
+        return render(request, 'generic-summary-template.html', variables)
 
     if request.method == 'POST':
 

--- a/application/views/contact_info.py
+++ b/application/views/contact_info.py
@@ -13,7 +13,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
-from .. table_util import create_tables, Table
+from ..table_util import create_tables, Table, submit_link_setter
 from ..summary_page_data import contact_info_link_dict, contact_info_name_dict
 from .. import magic_link, status
 from ..business_logic import login_contact_logic, reset_declaration, login_contact_logic_phone
@@ -203,6 +203,8 @@ def contact_summary(request):
             'login_details_status': application.login_details_status,
             'childcare_type_status': application.childcare_type_status
         }
+
+        variables = submit_link_setter(variables, table_list, 'login_details', app_id)
 
         return render(request, 'generic-summary-template.html', variables)
 

--- a/application/views/contact_info.py
+++ b/application/views/contact_info.py
@@ -13,7 +13,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
-from .. table_util import multi_table_magic, Table
+from .. table_util import create_tables, Table
 from ..summary_page_data import contact_info_link_dict, contact_info_name_dict
 from .. import magic_link, status
 from ..business_logic import login_contact_logic, reset_declaration, login_contact_logic_phone
@@ -191,7 +191,7 @@ def contact_summary(request):
                               'fields': contact_info_fields,
                               'title': 'Your login details',
                               'error_summary_title': 'There is something wrong with your login details'}
-        table_list = multi_table_magic([contact_info_table], contact_info_name_dict, contact_info_link_dict)
+        table_list = create_tables([contact_info_table], contact_info_name_dict, contact_info_link_dict)
 
         form = ContactSummaryForm()
         variables = {

--- a/application/views/dbs.py
+++ b/application/views/dbs.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from ..summary_page_data import dbs_summary_dict
-from .. table_util import table_creator
+from ..table_util import table_creator, submit_link_setter
 from .. import status
 from ..business_logic import (dbs_check_logic,
                               reset_declaration)
@@ -180,6 +180,7 @@ def dbs_check_summary(request):
             'table_list': table_list,
             'page_title': dbs_summary_dict['page_title']
         }
+        variables = submit_link_setter(variables, table_list, 'criminal_record_check', application_id_local)
 
         return render(request, 'generic-summary-template.html', variables)
     if request.method == 'POST':

--- a/application/views/dbs.py
+++ b/application/views/dbs.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
+from .. table_util import table_creator
 from .. import status
 from ..business_logic import (dbs_check_logic,
                               reset_declaration)
@@ -158,25 +159,36 @@ def dbs_check_summary(request):
     :param request: a request object used to generate the HttpResponse
     :return: an HttpResponse object with the rendered Your criminal record (DBS) check: summary template
     """
+    DATA_NAMES = ['dbs_certificate_number', 'cautions_convictions', 'send_certificate_declare']
+    DISPLAY_NAMES = ['DBS certificate number', 'Do you have any cautions or convictions?',
+                   'Will you send your DBS certificate to Ofsted?']
+    BACK_URL_NAMES = ['DBS-Check-DBS-Details-View', 'DBS-Check-DBS-Details-View', 'DBS-Check-Upload-DBS-View']
+    TABLE_NAMES = ['Check your answers: your criminal record check']
+    TABLE_ERROR_NAMES = ['There was a problem with your criminal record check']
+    PAGE_TITLE = 'Check your answers: criminal record (DBS) check'
+
     if request.method == 'GET':
         application_id_local = request.GET["id"]
-        criminal_record_check = CriminalRecordCheck.objects.get(
-            application_id=application_id_local)
-        dbs_certificate_number = criminal_record_check.dbs_certificate_number
-        cautions_convictions = criminal_record_check.cautions_convictions
-        send_certificate_declare = criminal_record_check.send_certificate_declare
+        criminal_record_check = CriminalRecordCheck.objects.get(application_id=application_id_local)
+        object_list = [criminal_record_check]
+
+        table_list = table_creator(object_list, DISPLAY_NAMES, DATA_NAMES,
+                                   TABLE_NAMES, TABLE_ERROR_NAMES, BACK_URL_NAMES)
+
         form = DBSCheckSummaryForm()
+
         application = Application.objects.get(pk=application_id_local)
         variables = {
             'form': form,
             'application_id': application_id_local,
-            'dbs_certificate_number': dbs_certificate_number,
-            'cautions_convictions': cautions_convictions,
             'criminal_record_check_status': application.criminal_record_check_status,
-            'declaration': send_certificate_declare
+            'table_list': table_list,
+            'page_title': PAGE_TITLE
         }
-        return render(request, 'dbs-check-summary.html', variables)
+
+        return render(request, 'generic-summary-template.html', variables)
     if request.method == 'POST':
+
         application_id_local = request.POST["id"]
         form = DBSCheckSummaryForm(request.POST)
         if form.is_valid():

--- a/application/views/dbs.py
+++ b/application/views/dbs.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
+from ..summary_page_data import dbs_summary_dict
 from .. table_util import table_creator
 from .. import status
 from ..business_logic import (dbs_check_logic,
@@ -159,21 +160,15 @@ def dbs_check_summary(request):
     :param request: a request object used to generate the HttpResponse
     :return: an HttpResponse object with the rendered Your criminal record (DBS) check: summary template
     """
-    DATA_NAMES = ['dbs_certificate_number', 'cautions_convictions', 'send_certificate_declare']
-    DISPLAY_NAMES = ['DBS certificate number', 'Do you have any cautions or convictions?',
-                   'Will you send your DBS certificate to Ofsted?']
-    BACK_URL_NAMES = ['DBS-Check-DBS-Details-View', 'DBS-Check-DBS-Details-View', 'DBS-Check-Upload-DBS-View']
-    TABLE_NAMES = ['Check your answers: your criminal record check']
-    TABLE_ERROR_NAMES = ['There was a problem with your criminal record check']
-    PAGE_TITLE = 'Check your answers: criminal record (DBS) check'
 
     if request.method == 'GET':
         application_id_local = request.GET["id"]
         criminal_record_check = CriminalRecordCheck.objects.get(application_id=application_id_local)
-        object_list = [criminal_record_check]
+        object_list = [[criminal_record_check]]
 
-        table_list = table_creator(object_list, DISPLAY_NAMES, DATA_NAMES,
-                                   TABLE_NAMES, TABLE_ERROR_NAMES, BACK_URL_NAMES)
+        table_list = table_creator(object_list, dbs_summary_dict['display_names'], dbs_summary_dict['data_names'],
+                                   dbs_summary_dict['table_names'], dbs_summary_dict['table_error_names'],
+                                   dbs_summary_dict['back_url_names'])
 
         form = DBSCheckSummaryForm()
 
@@ -183,7 +178,7 @@ def dbs_check_summary(request):
             'application_id': application_id_local,
             'criminal_record_check_status': application.criminal_record_check_status,
             'table_list': table_list,
-            'page_title': PAGE_TITLE
+            'page_title': dbs_summary_dict['page_title']
         }
 
         return render(request, 'generic-summary-template.html', variables)

--- a/application/views/declaration.py
+++ b/application/views/declaration.py
@@ -3,6 +3,7 @@ import datetime
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.core.urlresolvers import reverse
 
 from .. import status
 from ..forms import (DeclarationIntroForm,
@@ -293,6 +294,9 @@ def declaration_declaration(request):
                 application.save()
                 status.update(application_id_local,
                               'declarations_status', 'COMPLETED')
+                if application.application_status == 'FURTHER_INFORMATION':
+                    return HttpResponseRedirect(reverse('Awaiting-Review-View') + '?id=' + application_id_local + '&resubmitted=1')
+
                 return HttpResponseRedirect(settings.URL_PREFIX + '/payment?id=' + application_id_local)
             else:
                 variables = {

--- a/application/views/declaration_declaration.py
+++ b/application/views/declaration_declaration.py
@@ -70,6 +70,7 @@ def declaration_declaration(request):
                 application.save()
                 status.update(app_id,
                               'declarations_status', 'COMPLETED')
+
                 return HttpResponseRedirect(reverse('Payment-View') + '?id=' + app_id)
         else:
             variables = {

--- a/application/views/first_aid.py
+++ b/application/views/first_aid.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
-from ..table_util import Table, create_tables
+from ..table_util import Table, create_tables, submit_link_setter
 from ..summary_page_data import first_aid_name_dict, first_aid_link_dict
 from ..business_logic import (first_aid_logic,
                               reset_declaration)
@@ -281,6 +281,8 @@ def first_aid_training_summary(request):
             'page_title': 'Check your answers: first aid training',
             'first_aid_training_status': application.first_aid_training_status
         }
+
+        variables = submit_link_setter(variables, table_list, 'first_aid_training', application_id_local)
 
         return render(request, 'generic-summary-template.html', variables)
 

--- a/application/views/first_aid.py
+++ b/application/views/first_aid.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
-from ..table_util import Table, multi_table_magic
+from ..table_util import Table, create_tables
 from ..summary_page_data import first_aid_name_dict, first_aid_link_dict
 from ..business_logic import (first_aid_logic,
                               reset_declaration)
@@ -272,7 +272,7 @@ def first_aid_training_summary(request):
                            'fields': first_aid_fields,
                            'title': 'First aid training',
                            'error_summary_title': 'There is something wrong with your first aid training'}
-        table_list = multi_table_magic([first_aid_table], first_aid_name_dict, first_aid_link_dict)
+        table_list = create_tables([first_aid_table], first_aid_name_dict, first_aid_link_dict)
 
         variables = {
             'form': form,

--- a/application/views/first_aid.py
+++ b/application/views/first_aid.py
@@ -6,6 +6,8 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
+from ..table_util import Table, multi_table_magic
+from ..summary_page_data import first_aid_name_dict, first_aid_link_dict
 from ..business_logic import (first_aid_logic,
                               reset_declaration)
 from ..forms import (FirstAidTrainingDeclarationForm,
@@ -250,19 +252,38 @@ def first_aid_training_summary(request):
             application_id=application_id_local)
         form = FirstAidTrainingSummaryForm()
         application = Application.objects.get(pk=application_id_local)
+
+        first_aid_fields = {'first_aid_training_organisation': first_aid_record.training_organisation,
+                            'title_of_training_course': first_aid_record.course_title,
+                            'course_date': '/'.join([str(first_aid_record.course_day),
+                                                     str(first_aid_record.course_month),
+                                                     str(first_aid_record.course_year)])}
+        if first_aid_record.renew_certificate is True:
+            first_aid_fields['renew_certificate'] = first_aid_record.renew_certificate
+        else:
+            first_aid_fields['renew_certificate'] = None
+
+        if first_aid_record.show_certificate is True:
+            first_aid_fields['show_certificate'] = first_aid_record.show_certificate
+        else:
+            first_aid_fields['show_certificate'] = None
+
+        first_aid_table = {'table_object': Table([first_aid_record.pk]),
+                           'fields': first_aid_fields,
+                           'title': 'First aid training',
+                           'error_summary_title': 'There is something wrong with your first aid training'}
+        table_list = multi_table_magic([first_aid_table], first_aid_name_dict, first_aid_link_dict)
+
         variables = {
             'form': form,
             'application_id': application_id_local,
-            'training_organisation': first_aid_record.training_organisation,
-            'training_course': first_aid_record.course_title,
-            'certificate_day': first_aid_record.course_day,
-            'certificate_month': first_aid_record.course_month,
-            'certificate_year': first_aid_record.course_year,
-            'renew_certificate': first_aid_record.renew_certificate,
-            'show_certificate': first_aid_record.show_certificate,
+            'table_list': table_list,
+            'page_title': 'Check your answers: first aid training',
             'first_aid_training_status': application.first_aid_training_status
         }
-        return render(request, 'first-aid-summary.html', variables)
+
+        return render(request, 'generic-summary-template.html', variables)
+
     if request.method == 'POST':
         application_id_local = request.POST["id"]
         form = FirstAidTrainingSummaryForm(request.POST)

--- a/application/views/health.py
+++ b/application/views/health.py
@@ -5,6 +5,8 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
+from ..table_util import Table, multi_table_magic
+from ..summary_page_data import health_link_dict, health_name_dict
 from ..business_logic import (health_check_logic,
                               reset_declaration)
 from ..forms import (HealthBookletForm,
@@ -99,17 +101,28 @@ def health_check_answers(request):
     """
     if request.method == 'GET':
         application_id_local = request.GET["id"]
-        send_hdb_declare = HealthDeclarationBooklet.objects.get(
-            application_id=application_id_local).send_hdb_declare
+        health_record = HealthDeclarationBooklet.objects.get(
+            application_id=application_id_local)
+        send_hdb_declare = health_record.send_hdb_declare
         form = HealthBookletForm(id=application_id_local)
         application = Application.objects.get(pk=application_id_local)
+
+        health_fields = {'health_submission_consent': send_hdb_declare}
+
+        health_table = {'table_object': Table([health_record.pk]),
+                        'fields': health_fields,
+                        'title': 'Your health',
+                        'error_summary_title': 'There is something wrong with your health'}
+        table_list = multi_table_magic([health_table], health_name_dict, health_link_dict)
+
         variables = {
             'form': form,
             'application_id': application_id_local,
-            'send_hdb_declare': send_hdb_declare,
+            'table_list': table_list,
             'health_status': application.health_status,
+            'page_title': 'Check your answers: your health'
         }
-        return render(request, 'health-check-answers.html', variables)
+        return render(request, 'generic-summary-template.html', variables)
     if request.method == 'POST':
         application_id_local = request.POST["id"]
         form = HealthBookletForm(request.POST, id=application_id_local)

--- a/application/views/health.py
+++ b/application/views/health.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
-from ..table_util import Table, multi_table_magic
+from ..table_util import Table, create_tables
 from ..summary_page_data import health_link_dict, health_name_dict
 from ..business_logic import (health_check_logic,
                               reset_declaration)
@@ -113,7 +113,7 @@ def health_check_answers(request):
                         'fields': health_fields,
                         'title': 'Your health',
                         'error_summary_title': 'There is something wrong with your health'}
-        table_list = multi_table_magic([health_table], health_name_dict, health_link_dict)
+        table_list = create_tables([health_table], health_name_dict, health_link_dict)
 
         variables = {
             'form': form,

--- a/application/views/health.py
+++ b/application/views/health.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
-from ..table_util import Table, create_tables
+from ..table_util import Table, create_tables, submit_link_setter
 from ..summary_page_data import health_link_dict, health_name_dict
 from ..business_logic import (health_check_logic,
                               reset_declaration)
@@ -122,6 +122,8 @@ def health_check_answers(request):
             'health_status': application.health_status,
             'page_title': 'Check your answers: your health'
         }
+        variables = submit_link_setter(variables, table_list, 'health', application_id_local)
+
         return render(request, 'generic-summary-template.html', variables)
     if request.method == 'POST':
         application_id_local = request.POST["id"]

--- a/application/views/other_people.py
+++ b/application/views/other_people.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
-from ..table_util import multi_table_magic, Table
+from ..table_util import create_tables, Table
 from ..summary_page_data import other_adult_link_dict, other_adult_name_dict, other_child_link_dict,\
                                 other_child_name_dict, other_adult_summary_link_dict, other_adult_summary_name_dict,\
                                 other_child_summary_name_dict, other_child_summary_link_dict
@@ -763,7 +763,7 @@ def other_people_summary(request):
         back_link_addition = '&adults=' + str((len(adult_table_list))) + '&remove=0'
         for table in adult_table_list:
             table['other_people_numbers'] = back_link_addition
-        adult_table_list = multi_table_magic(adult_table_list, other_adult_name_dict, other_adult_link_dict)
+        adult_table_list = create_tables(adult_table_list, other_adult_name_dict, other_adult_link_dict)
 
         child_table_list = []
         for child in children_list:
@@ -785,7 +785,7 @@ def other_people_summary(request):
         back_link_addition = '&children=' + str(len(child_table_list)) + '&remove=0'
         for table in child_table_list:
             table['other_people_numbers'] = back_link_addition
-        child_table_list = multi_table_magic(child_table_list, other_child_name_dict, other_child_link_dict, )
+        child_table_list = create_tables(child_table_list, other_child_name_dict, other_child_link_dict, )
 
 
         if not adult_table_list:
@@ -806,8 +806,8 @@ def other_people_summary(request):
                        'fields': {'children_in_home': children_in_home},
                        'title': 'Children in your home',
                        'error_summary_title': 'There is a problem with the children in your home'}
-        adult_table = multi_table_magic([adult_table], other_adult_summary_name_dict, other_adult_summary_link_dict)
-        child_table = multi_table_magic([child_table], other_child_summary_name_dict, other_child_summary_link_dict)
+        adult_table = create_tables([adult_table], other_adult_summary_name_dict, other_adult_summary_link_dict)
+        child_table = create_tables([child_table], other_child_summary_name_dict, other_child_summary_link_dict)
 
         table_list = adult_table + child_table + adult_table_list + child_table_list
 

--- a/application/views/other_people.py
+++ b/application/views/other_people.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
-from ..table_util import create_tables, Table
+from ..table_util import create_tables, Table, submit_link_setter
 from ..summary_page_data import other_adult_link_dict, other_adult_name_dict, other_child_link_dict,\
                                 other_child_name_dict, other_adult_summary_link_dict, other_adult_summary_name_dict,\
                                 other_child_summary_name_dict, other_child_summary_link_dict
@@ -819,6 +819,8 @@ def other_people_summary(request):
             'turning_16': application.children_turning_16,
             'people_in_home_status': application.people_in_home_status
         }
+        variables = submit_link_setter(variables, table_list, 'people_in_home', application_id_local)
+
         status.update(application_id_local,
                       'people_in_home_status', 'COMPLETED')
         return render(request, 'generic-summary-template.html', variables)

--- a/application/views/other_people.py
+++ b/application/views/other_people.py
@@ -1,4 +1,5 @@
 import datetime
+import calendar
 from datetime import date
 
 from django.conf import settings
@@ -6,6 +7,10 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
 from .. import status
+from ..table_util import multi_table_magic, Table
+from ..summary_page_data import other_adult_link_dict, other_adult_name_dict, other_child_link_dict,\
+                                other_child_name_dict, other_adult_summary_link_dict, other_adult_summary_name_dict,\
+                                other_child_summary_name_dict, other_child_summary_link_dict
 from ..business_logic import (other_people_adult_details_logic,
                               other_people_children_details_logic,
                               rearrange_adults,
@@ -734,47 +739,89 @@ def other_people_summary(request):
         child_relationship_list = []
         form = OtherPeopleSummaryForm()
         application = Application.objects.get(pk=application_id_local)
+        adult_table_list = []
+        adult_lists = zip(adult_name_list, adult_birth_day_list, adult_birth_month_list, adult_birth_year_list,
+                          adult_relationship_list, adult_dbs_list, adult_permission_list)
         for adult in adults_list:
             if adult.middle_names != '':
                 name = adult.first_name + ' ' + adult.middle_names + ' ' + adult.last_name
             elif adult.middle_names == '':
                 name = adult.first_name + ' ' + adult.last_name
-            adult_name_list.append(name)
-            adult_birth_day_list.append(adult.birth_day)
-            adult_birth_month_list.append(adult.birth_month)
-            adult_birth_year_list.append(adult.birth_year)
-            adult_relationship_list.append(adult.relationship)
-            adult_dbs_list.append(adult.dbs_certificate_number)
-            adult_permission_list.append(adult.permission_declare)
-        adult_lists = zip(adult_name_list, adult_birth_day_list, adult_birth_month_list, adult_birth_year_list,
-                          adult_relationship_list, adult_dbs_list, adult_permission_list)
+            birth_date = ' '.join([str(adult.birth_day),calendar.month_name[adult.birth_month],str(adult.birth_year)])
+            other_adult_fields = {'full_name': name,
+                                  'date_of_birth': birth_date,
+                                  'relationship': adult.relationship,
+                                  'dbs_certificate_number': adult.dbs_certificate_number,
+                                  'permission': adult.permission_declare}
+
+            other_adult_table = {'table_object': Table([adult.pk]),
+                                 'fields': other_adult_fields,
+                                 'title': name,
+                                 'error_summary_title': ('There is something wrong with a persons details ('
+                                                         + name + ')')}
+            adult_table_list.append(other_adult_table)
+        back_link_addition = '&adults=' + str((len(adult_table_list))) + '&remove=0'
+        for table in adult_table_list:
+            table['other_people_numbers'] = back_link_addition
+        adult_table_list = multi_table_magic(adult_table_list, other_adult_name_dict, other_adult_link_dict)
+
+        child_table_list = []
         for child in children_list:
             if child.middle_names != '':
                 name = child.first_name + ' ' + child.middle_names + ' ' + child.last_name
             elif child.middle_names == '':
                 name = child.first_name + ' ' + child.last_name
-            child_name_list.append(name)
-            child_birth_day_list.append(child.birth_day)
-            child_birth_month_list.append(child.birth_month)
-            child_birth_year_list.append(child.birth_year)
-            child_relationship_list.append(child.relationship)
-        child_lists = zip(child_name_list, child_birth_day_list, child_birth_month_list, child_birth_year_list,
-                          child_relationship_list)
+            other_child_fields = {'full_name': name,
+                                  'date_of_birth': ' '.join([str(child.birth_day),
+                                                             calendar.month_name[child.birth_month],
+                                                             str(child.birth_year)]),
+                                  'relationship': child.relationship}
+
+            other_child_table = {'table_object': Table([child.pk]),
+                                 'fields': other_child_fields,
+                                 'title': name,
+                                 'error_summary_title': 'child test'}
+            child_table_list.append(other_child_table)
+        back_link_addition = '&children=' + str(len(child_table_list)) + '&remove=0'
+        for table in child_table_list:
+            table['other_people_numbers'] = back_link_addition
+        child_table_list = multi_table_magic(child_table_list, other_child_name_dict, other_child_link_dict, )
+
+
+        if not adult_table_list:
+            adults_in_home = False
+        else:
+            adults_in_home = True
+
+        if not child_table_list:
+            children_in_home = False
+        else:
+            children_in_home = True
+
+        adult_table = {'table_object': Table([application_id_local]),
+                       'fields': {'adults_in_home': adults_in_home},
+                       'title': 'Adults in your home',
+                       'error_summary_title': 'There is a problem with the adults in your home'}
+        child_table = {'table_object': Table([application_id_local]),
+                       'fields': {'children_in_home': children_in_home},
+                       'title': 'Children in your home',
+                       'error_summary_title': 'There is a problem with the children in your home'}
+        adult_table = multi_table_magic([adult_table], other_adult_summary_name_dict, other_adult_summary_link_dict)
+        child_table = multi_table_magic([child_table], other_child_summary_name_dict, other_child_summary_link_dict)
+
+        table_list = adult_table + child_table + adult_table_list + child_table_list
+
         variables = {
+            'page_title': 'Check your answers: people in your home',
             'form': form,
             'application_id': application_id_local,
-            'adults_in_home': application.adults_in_home,
-            'children_in_home': application.children_in_home,
-            'number_of_adults': adults_list.count(),
-            'number_of_children': children_list.count(),
-            'adult_lists': adult_lists,
-            'child_lists': child_lists,
+            'table_list': table_list,
             'turning_16': application.children_turning_16,
             'people_in_home_status': application.people_in_home_status
         }
         status.update(application_id_local,
                       'people_in_home_status', 'COMPLETED')
-        return render(request, 'other-people-summary.html', variables)
+        return render(request, 'generic-summary-template.html', variables)
     if request.method == 'POST':
         application_id_local = request.POST["id"]
         form = OtherPeopleSummaryForm()

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
-from .. table_util import Table, Row, multi_table_magic
+from .. table_util import Table, Row, create_tables
 from .. summary_page_data import personal_details_name_dict, personal_details_link_dict
 from .. import address_helper, status
 from ..business_logic import (multiple_childcare_address_logic,
@@ -820,7 +820,7 @@ def personal_details_summary(request):
                         'error_summary_title': 'There is something wrong with your address'}
 
         tables = [name_dob_dict, address_dict]
-        table_list = multi_table_magic(tables, personal_details_name_dict, personal_details_link_dict)
+        table_list = create_tables(tables, personal_details_name_dict, personal_details_link_dict)
 
         form = PersonalDetailsSummaryForm()
         application = Application.get_id(app_id=app_id)

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
-from .. table_util import Table, Row, create_tables
+from ..table_util import Table, Row, create_tables, submit_link_setter
 from .. summary_page_data import personal_details_name_dict, personal_details_link_dict
 from .. import address_helper, status
 from ..business_logic import (multiple_childcare_address_logic,
@@ -833,6 +833,8 @@ def personal_details_summary(request):
             'page_title': 'Check your answers: your personal details',
             'personal_details_status': application.personal_details_status
         }
+        variables = submit_link_setter(variables, table_list, 'personal_details', app_id)
+
         return render(request, 'generic-summary-template.html', variables)
 
     if request.method == 'POST':

--- a/application/views/references.py
+++ b/application/views/references.py
@@ -6,7 +6,7 @@ from django.shortcuts import render
 
 from ..summary_page_data import first_reference_name_dict, first_reference_link_dict,\
                                 second_reference_name_dict, second_reference_link_dict
-from ..table_util import Table, multi_table_magic
+from ..table_util import Table, create_tables
 from .. import address_helper, status
 from ..business_logic import (references_first_reference_logic,
                               references_second_reference_logic,
@@ -685,8 +685,8 @@ def references_summary(request):
                                  'fields': first_reference_fields,
                                  'title': 'First reference',
                                  'error_summary_title': "There's something wrong with your first reference"}
-        first_reference_table = multi_table_magic([first_reference_table], first_reference_name_dict,
-                                                  first_reference_link_dict)
+        first_reference_table = create_tables([first_reference_table], first_reference_name_dict,
+                                              first_reference_link_dict)
 
         second_reference_fields = {'full_name': ' '.join([second_reference_first_name, second_reference_last_name]),
                                    'relationship': second_reference_relationship,
@@ -702,8 +702,8 @@ def references_summary(request):
                                   'fields': second_reference_fields,
                                   'title': 'Second reference',
                                   'error_summary_title': "There's something wrong with your first reference"}
-        second_reference_table = multi_table_magic([second_reference_table], second_reference_name_dict,
-                                                    second_reference_link_dict)
+        second_reference_table = create_tables([second_reference_table], second_reference_name_dict,
+                                               second_reference_link_dict)
         table_list = first_reference_table + second_reference_table
 
         status.update(application_id_local, 'references_status', 'COMPLETED')

--- a/application/views/references.py
+++ b/application/views/references.py
@@ -4,6 +4,9 @@ from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
+from ..summary_page_data import first_reference_name_dict, first_reference_link_dict,\
+                                second_reference_name_dict, second_reference_link_dict
+from ..table_util import Table, multi_table_magic
 from .. import address_helper, status
 from ..business_logic import (references_first_reference_logic,
                               references_second_reference_logic,
@@ -668,39 +671,50 @@ def references_summary(request):
         second_reference_email = second_reference_record.email
         form = ReferenceSummaryForm()
         application = Application.objects.get(pk=application_id_local)
+
+        first_reference_fields = {'full_name': ' '.join([first_reference_first_name, first_reference_last_name]),
+                                  'relationship': first_reference_relationship,
+                                  'known_for': ' '.join([str(first_reference_years_known), 'years,',
+                                                         str(first_reference_months_known), 'months']),
+                                  'address': ' '.join([first_reference_street_line1, (first_reference_street_line2 or ''),
+                                                       first_reference_town, (first_reference_county or ''),
+                                                       first_reference_postcode, first_reference_country]),
+                                  'phone_number': first_reference_phone_number,
+                                  'email_address': first_reference_email}
+        first_reference_table = {'table_object': Table([first_reference_record.pk]),
+                                 'fields': first_reference_fields,
+                                 'title': 'First reference',
+                                 'error_summary_title': "There's something wrong with your first reference"}
+        first_reference_table = multi_table_magic([first_reference_table], first_reference_name_dict,
+                                                  first_reference_link_dict)
+
+        second_reference_fields = {'full_name': ' '.join([second_reference_first_name, second_reference_last_name]),
+                                   'relationship': second_reference_relationship,
+                                   'known_for': ' '.join([str(second_reference_years_known), 'years,',
+                                                          str(second_reference_months_known), 'months']),
+                                   'address': ' '.join(
+                                      [second_reference_street_line1, (second_reference_street_line2 or ''),
+                                       second_reference_town, (second_reference_county or ''),
+                                       second_reference_postcode, second_reference_country]),
+                                   'phone_number': second_reference_phone_number,
+                                   'email_address': second_reference_email}
+        second_reference_table = {'table_object': Table([second_reference_record.pk]),
+                                  'fields': second_reference_fields,
+                                  'title': 'Second reference',
+                                  'error_summary_title': "There's something wrong with your first reference"}
+        second_reference_table = multi_table_magic([second_reference_table], second_reference_name_dict,
+                                                    second_reference_link_dict)
+        table_list = first_reference_table + second_reference_table
+
         status.update(application_id_local, 'references_status', 'COMPLETED')
         variables = {
             'form': form,
             'application_id': application_id_local,
-            'first_reference_first_name': first_reference_first_name,
-            'first_reference_last_name': first_reference_last_name,
-            'first_reference_relationship': first_reference_relationship,
-            'first_reference_years_known': first_reference_years_known,
-            'first_reference_months_known': first_reference_months_known,
-            'first_reference_street_line1': first_reference_street_line1,
-            'first_reference_street_line2': first_reference_street_line2,
-            'first_reference_town': first_reference_town,
-            'first_reference_county': first_reference_county,
-            'first_reference_country': first_reference_country,
-            'first_reference_postcode': first_reference_postcode,
-            'first_reference_phone_number': first_reference_phone_number,
-            'first_reference_email': first_reference_email,
-            'second_reference_first_name': second_reference_first_name,
-            'second_reference_last_name': second_reference_last_name,
-            'second_reference_relationship': second_reference_relationship,
-            'second_reference_years_known': second_reference_years_known,
-            'second_reference_months_known': second_reference_months_known,
-            'second_reference_street_line1': second_reference_street_line1,
-            'second_reference_street_line2': second_reference_street_line2,
-            'second_reference_town': second_reference_town,
-            'second_reference_county': second_reference_county,
-            'second_reference_country': second_reference_country,
-            'second_reference_postcode': second_reference_postcode,
-            'second_reference_phone_number': second_reference_phone_number,
-            'second_reference_email': second_reference_email,
-            'references_status': application.references_status
+            'table_list': table_list,
+            'page_title': 'Check your answers: references',
+            'references_status': application.references_status,
         }
-        return render(request, 'references-summary.html', variables)
+        return render(request, 'generic-summary-template.html', variables)
     if request.method == 'POST':
         application_id_local = request.POST["id"]
         form = ReferenceSummaryForm()

--- a/application/views/references.py
+++ b/application/views/references.py
@@ -6,7 +6,7 @@ from django.shortcuts import render
 
 from ..summary_page_data import first_reference_name_dict, first_reference_link_dict,\
                                 second_reference_name_dict, second_reference_link_dict
-from ..table_util import Table, create_tables
+from ..table_util import Table, create_tables, submit_link_setter
 from .. import address_helper, status
 from ..business_logic import (references_first_reference_logic,
                               references_second_reference_logic,
@@ -714,6 +714,8 @@ def references_summary(request):
             'page_title': 'Check your answers: references',
             'references_status': application.references_status,
         }
+        variables = submit_link_setter(variables, table_list, 'references', application_id_local)
+
         return render(request, 'generic-summary-template.html', variables)
     if request.method == 'POST':
         application_id_local = request.POST["id"]

--- a/db.json
+++ b/db.json
@@ -1,60 +1,95 @@
 [
 {
-  "model": "govuk_template_base.servicesettings",
-  "pk": 1,
+  "model": "auth.group",
   "fields": {
-    "modified": "2018-03-20T13:16:41.855Z",
-    "name": "Untitled",
-    "localise_name": false,
-    "phase": "discovery",
-    "header_link_view_name": "",
-    "header_links": [],
-    "footer_links": []
+    "name": "arc",
+    "permissions": []
   }
 },
 {
-  "model": "govuk_template_base.servicesettings",
-  "pk": 2,
+  "model": "auth.group",
   "fields": {
-    "modified": "2018-03-20T13:16:41.855Z",
-    "name": "Untitled",
-    "localise_name": false,
-    "phase": "discovery",
-    "header_link_view_name": "",
-    "header_links": [],
-    "footer_links": []
+    "name": "contact-centre",
+    "permissions": []
   }
 },
 {
-  "model": "timeline_logger.timelinelog",
-  "pk": 1,
+  "model": "auth.user",
   "fields": {
-    "content_type": [
-      "application",
-      "application"
+    "password": "pbkdf2_sha256$36000$0LmFEZxDRGCu$lAZrw1t7xlrEw+bwkv43Npyx7eGYGDVMFg6qHeptuMo=",
+    "last_login": "2018-03-27T08:25:33.891Z",
+    "is_superuser": false,
+    "username": "arc1",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2018-03-01T10:16:32Z",
+    "groups": [
+      [
+        "arc"
+      ]
     ],
-    "object_id": "48e0b0f3-21e6-4ebd-b9a5-79d4c763f2b2",
-    "timestamp": "2018-03-21T18:14:24.295Z",
-    "extra_data": {
-      "action": "drafted",
-      "user_type": "applicant"
-    },
-    "user": null,
-    "template": "timeline_logger/application_action.txt"
+    "user_permissions": []
   }
 },
 {
-  "model": "application.auditlog",
-  "pk": "dff7d296-4af8-4b51-8aa5-34802c026644",
+  "model": "auth.user",
   "fields": {
-    "audit_message": "[{\"user\": \"Applicant\", \"message\": \"Application has been created\", \"date\": \"20/03/2018\"},{\"user\": \"Applicant\", \"message\": \"Submitted by applicant\", \"date\": \"20/03/2018\"}]"
+    "password": "pbkdf2_sha256$36000$0LmFEZxDRGCu$lAZrw1t7xlrEw+bwkv43Npyx7eGYGDVMFg6qHeptuMo=",
+    "last_login": "2018-03-05T09:01:10.474Z",
+    "is_superuser": false,
+    "username": "cc1",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2018-03-01T10:16:32Z",
+    "groups": [
+      [
+        "contact-centre"
+      ]
+    ],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "fields": {
+    "password": "default-password",
+    "last_login": null,
+    "is_superuser": true,
+    "username": "root",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": true,
+    "is_active": true,
+    "date_joined": "2018-03-26T10:39:47.333Z",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "govuk_template_base.servicesettings",
+  "pk": 1,
+  "fields": {
+    "modified": "2018-03-23T10:23:55.796Z",
+    "name": "Untitled",
+    "localise_name": false,
+    "phase": "discovery",
+    "header_link_view_name": "",
+    "header_links": [],
+    "footer_links": []
   }
 },
 {
   "model": "application.userdetails",
-  "pk": "00bc7a4b-ad42-4004-9ea6-7c1d67888eca",
+  "pk": "0ca55d86-3e3f-49b1-b5c2-01e08581c92e",
   "fields": {
-    "email": "dsfdfgddf@sdlfkjkaskf.com",
+    "email": "cheeeese@cheeekjwehiui2efukuhjeffeheeeese.com",
     "mobile_number": "07824893361",
     "add_phone_number": "",
     "email_expiry_date": null,
@@ -67,30 +102,105 @@
 },
 {
   "model": "application.userdetails",
-  "pk": "ab627a88-7458-4431-aa44-a01e8b2c85b5",
+  "pk": "317983ce-8159-41e0-b2cc-09bef17e2ffe",
   "fields": {
-    "email": "holms@holms.lt",
-    "mobile_number": "0786647894",
+    "email": "oijo@okw.com",
+    "mobile_number": "07864647894",
     "add_phone_number": "",
     "email_expiry_date": 0,
-    "sms_expiry_date": 1521732312,
-    "magic_link_email": "0KIJ1ZT11VC1",
-    "magic_link_sms": "04070",
-    "security_question": null,
-    "security_answer": null
+    "sms_expiry_date": 1522139696,
+    "magic_link_email": "VHNLFTHVI6BN",
+    "magic_link_sms": "11066",
+    "security_question": "oqisjoij",
+    "security_answer": "oijoij"
+  }
+},
+{
+  "model": "application.userdetails",
+  "pk": "47e22c31-f301-490f-9ad3-16c10cf234a4",
+  "fields": {
+    "email": "hugo.geeves@informed.com",
+    "mobile_number": "07864647894",
+    "add_phone_number": "07864647899",
+    "email_expiry_date": 0,
+    "sms_expiry_date": 1522078966,
+    "magic_link_email": "EB1WQB011OKZ",
+    "magic_link_sms": "32345",
+    "security_question": "oiujoj",
+    "security_answer": "oijoij"
+  }
+},
+{
+  "model": "application.userdetails",
+  "pk": "5756655c-21bb-4972-b31b-9b1cf7d52d80",
+  "fields": {
+    "email": "hugo.geeves@informed.comd",
+    "mobile_number": "07864647894",
+    "add_phone_number": "",
+    "email_expiry_date": null,
+    "sms_expiry_date": null,
+    "magic_link_email": null,
+    "magic_link_sms": null,
+    "security_question": "uihiuh",
+    "security_answer": "iuhih"
+  }
+},
+{
+  "model": "application.userdetails",
+  "pk": "941c0f47-584a-42b0-aa6e-a355a45e2670",
+  "fields": {
+    "email": "iuhiuh@iuhfe.com",
+    "mobile_number": "07864647894",
+    "add_phone_number": "",
+    "email_expiry_date": null,
+    "sms_expiry_date": null,
+    "magic_link_email": null,
+    "magic_link_sms": null,
+    "security_question": "wdojho",
+    "security_answer": "poijio"
+  }
+},
+{
+  "model": "application.userdetails",
+  "pk": "b3250923-edcf-4f58-ac56-a45686bbf539",
+  "fields": {
+    "email": "fudhoiu@oiwjefij.com",
+    "mobile_number": "07864647894",
+    "add_phone_number": "",
+    "email_expiry_date": null,
+    "sms_expiry_date": null,
+    "magic_link_email": null,
+    "magic_link_sms": null,
+    "security_question": "oijoj",
+    "security_answer": "oijoiji"
+  }
+},
+{
+  "model": "application.userdetails",
+  "pk": "c750c89d-73ba-4180-b777-447e16adb735",
+  "fields": {
+    "email": "iouahsdua@iuwhefiuh.com",
+    "mobile_number": "07864647894",
+    "add_phone_number": "",
+    "email_expiry_date": null,
+    "sms_expiry_date": null,
+    "magic_link_email": null,
+    "magic_link_sms": null,
+    "security_question": "yiuhiiuhu",
+    "security_answer": "erererres"
   }
 },
 {
   "model": "application.application",
-  "pk": "48e0b0f3-21e6-4ebd-b9a5-79d4c763f2b2",
+  "pk": "18bbe6a1-e8c7-4c37-9d65-2299a59df4a5",
   "fields": {
-    "login_id": "ab627a88-7458-4431-aa44-a01e8b2c85b5",
+    "login_id": "5756655c-21bb-4972-b31b-9b1cf7d52d80",
     "application_type": "CHILDMINDER",
     "application_status": "DRAFTING",
     "cygnum_urn": "",
-    "login_details_status": "NOT_STARTED",
+    "login_details_status": "COMPLETED",
     "personal_details_status": "NOT_STARTED",
-    "childcare_type_status": "NOT_STARTED",
+    "childcare_type_status": "IN_PROGRESS",
     "first_aid_training_status": "NOT_STARTED",
     "eyfs_training_status": "COMPLETED",
     "criminal_record_check_status": "NOT_STARTED",
@@ -107,8 +217,8 @@
     "share_info_declare": null,
     "information_correct_declare": null,
     "change_declare": null,
-    "date_created": "2018-03-21T18:14:24.239Z",
-    "date_updated": "2018-03-21T18:16:18.030Z",
+    "date_created": "2018-03-26T13:49:14.200Z",
+    "date_updated": "2018-03-26T13:49:49.725Z",
     "date_accepted": null,
     "order_code": null,
     "date_submitted": null
@@ -116,9 +226,77 @@
 },
 {
   "model": "application.application",
-  "pk": "dff7d296-4af8-4b51-8aa5-34802c026644",
+  "pk": "27f25bec-677e-40b5-adc2-0c0f8a7c62d6",
   "fields": {
-    "login_id": "00bc7a4b-ad42-4004-9ea6-7c1d67888eca",
+    "login_id": "c750c89d-73ba-4180-b777-447e16adb735",
+    "application_type": "CHILDMINDER",
+    "application_status": "DRAFTING",
+    "cygnum_urn": "",
+    "login_details_status": "COMPLETE",
+    "personal_details_status": "COMPLETED",
+    "childcare_type_status": "COMPLETED",
+    "first_aid_training_status": "NOT_STARTED",
+    "eyfs_training_status": "COMPLETED",
+    "criminal_record_check_status": "NOT_STARTED",
+    "health_status": "NOT_STARTED",
+    "references_status": "NOT_STARTED",
+    "people_in_home_status": "NOT_STARTED",
+    "adults_in_home": null,
+    "children_in_home": null,
+    "children_turning_16": null,
+    "declarations_status": "NOT_STARTED",
+    "background_check_declare": null,
+    "inspect_home_declare": null,
+    "interview_declare": null,
+    "share_info_declare": null,
+    "information_correct_declare": null,
+    "change_declare": null,
+    "date_created": "2018-03-26T14:15:30.611Z",
+    "date_updated": "2018-03-26T15:42:16.537Z",
+    "date_accepted": null,
+    "order_code": null,
+    "date_submitted": null
+  }
+},
+{
+  "model": "application.application",
+  "pk": "6595758e-2643-4ee4-a9d8-81906fe42d29",
+  "fields": {
+    "login_id": "b3250923-edcf-4f58-ac56-a45686bbf539",
+    "application_type": "CHILDMINDER",
+    "application_status": "DRAFTING",
+    "cygnum_urn": "",
+    "login_details_status": "COMPLETED",
+    "personal_details_status": "NOT_STARTED",
+    "childcare_type_status": "IN_PROGRESS",
+    "first_aid_training_status": "NOT_STARTED",
+    "eyfs_training_status": "COMPLETED",
+    "criminal_record_check_status": "NOT_STARTED",
+    "health_status": "NOT_STARTED",
+    "references_status": "NOT_STARTED",
+    "people_in_home_status": "NOT_STARTED",
+    "adults_in_home": null,
+    "children_in_home": null,
+    "children_turning_16": null,
+    "declarations_status": "NOT_STARTED",
+    "background_check_declare": null,
+    "inspect_home_declare": null,
+    "interview_declare": null,
+    "share_info_declare": null,
+    "information_correct_declare": null,
+    "change_declare": null,
+    "date_created": "2018-03-26T13:25:17.402Z",
+    "date_updated": "2018-03-26T13:25:30.286Z",
+    "date_accepted": null,
+    "order_code": null,
+    "date_submitted": null
+  }
+},
+{
+  "model": "application.application",
+  "pk": "913092e3-2ff5-4a4f-82ce-18d69badd56e",
+  "fields": {
+    "login_id": "0ca55d86-3e3f-49b1-b5c2-01e08581c92e",
     "application_type": "CHILDMINDER",
     "application_status": "SUBMITTED",
     "cygnum_urn": "",
@@ -141,49 +319,255 @@
     "share_info_declare": true,
     "information_correct_declare": true,
     "change_declare": null,
-    "date_created": "2018-03-20T13:16:56.329Z",
-    "date_updated": "2018-03-20T13:17:47.999Z",
+    "date_created": "2018-03-23T10:24:53.090Z",
+    "date_updated": "2018-03-23T10:26:49.427Z",
     "date_accepted": null,
-    "order_code": "e388e36e-dc39-41fd-8e22-4b7dc4bb75ee",
-    "date_submitted": "2018-03-20T13:18:04.669Z"
+    "order_code": "4c81849c-97c0-4a9c-b5b5-62ceb638dcd7",
+    "date_submitted": "2018-03-23T10:27:12.306Z"
   }
 },
 {
-  "model": "application.childcaretype",
-  "pk": "7b521180-ba1a-44e6-9c07-3a9bc50928f2",
+  "model": "application.application",
+  "pk": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
   "fields": {
-    "application_id": "dff7d296-4af8-4b51-8aa5-34802c026644",
-    "zero_to_five": true,
-    "five_to_eight": true,
-    "eight_plus": false
+    "login_id": "47e22c31-f301-490f-9ad3-16c10cf234a4",
+    "application_type": "CHILDMINDER",
+    "application_status": "FURTHER_INFORMATION",
+    "cygnum_urn": "",
+    "login_details_status": "COMPLETED",
+    "personal_details_status": "COMPLETED",
+    "childcare_type_status": "COMPLETED",
+    "first_aid_training_status": "COMPLETED",
+    "eyfs_training_status": "COMPLETED",
+    "criminal_record_check_status": "COMPLETED",
+    "health_status": "COMPLETED",
+    "references_status": "IN_PROGRESS",
+    "people_in_home_status": "COMPLETED",
+    "adults_in_home": true,
+    "children_in_home": true,
+    "children_turning_16": false,
+    "declarations_status": "NOT_STARTED",
+    "background_check_declare": null,
+    "inspect_home_declare": null,
+    "interview_declare": null,
+    "share_info_declare": null,
+    "information_correct_declare": null,
+    "change_declare": null,
+    "date_created": "2018-03-26T09:50:58.363Z",
+    "date_updated": "2018-03-26T16:02:08.172Z",
+    "date_accepted": null,
+    "order_code": "beb2a73f-9121-4607-b536-31a384eed80a",
+    "date_submitted": "2018-03-26T10:26:06.476Z"
+  }
+},
+{
+  "model": "application.application",
+  "pk": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+  "fields": {
+    "login_id": "941c0f47-584a-42b0-aa6e-a355a45e2670",
+    "application_type": "CHILDMINDER",
+    "application_status": "DRAFTING",
+    "cygnum_urn": "",
+    "login_details_status": "COMPLETED",
+    "personal_details_status": "COMPLETED",
+    "childcare_type_status": "COMPLETED",
+    "first_aid_training_status": "COMPLETED",
+    "eyfs_training_status": "COMPLETED",
+    "criminal_record_check_status": "COMPLETED",
+    "health_status": "COMPLETED",
+    "references_status": "COMPLETED",
+    "people_in_home_status": "COMPLETED",
+    "adults_in_home": true,
+    "children_in_home": true,
+    "children_turning_16": false,
+    "declarations_status": "NOT_STARTED",
+    "background_check_declare": null,
+    "inspect_home_declare": null,
+    "interview_declare": null,
+    "share_info_declare": null,
+    "information_correct_declare": null,
+    "change_declare": null,
+    "date_created": "2018-03-23T11:08:20.189Z",
+    "date_updated": "2018-03-26T09:44:47.779Z",
+    "date_accepted": null,
+    "order_code": null,
+    "date_submitted": null
+  }
+},
+{
+  "model": "application.application",
+  "pk": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+  "fields": {
+    "login_id": "317983ce-8159-41e0-b2cc-09bef17e2ffe",
+    "application_type": "CHILDMINDER",
+    "application_status": "SUBMITTED",
+    "cygnum_urn": "",
+    "login_details_status": "COMPLETE",
+    "personal_details_status": "COMPLETED",
+    "childcare_type_status": "COMPLETED",
+    "first_aid_training_status": "COMPLETED",
+    "eyfs_training_status": "COMPLETED",
+    "criminal_record_check_status": "COMPLETED",
+    "health_status": "COMPLETED",
+    "references_status": "COMPLETED",
+    "people_in_home_status": "COMPLETED",
+    "adults_in_home": false,
+    "children_in_home": false,
+    "children_turning_16": false,
+    "declarations_status": "COMPLETED",
+    "background_check_declare": true,
+    "inspect_home_declare": true,
+    "interview_declare": true,
+    "share_info_declare": true,
+    "information_correct_declare": true,
+    "change_declare": null,
+    "date_created": "2018-03-26T16:50:51.013Z",
+    "date_updated": "2018-03-27T08:42:57.381Z",
+    "date_accepted": null,
+    "order_code": "82d71553-b7e8-4011-a514-028efcb60cd3",
+    "date_submitted": "2018-03-26T16:59:51.251Z"
+  }
+},
+{
+  "model": "application.adultinhome",
+  "pk": "1db0c0af-d00c-4897-8f2c-1821754ed33b",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "adult": 2,
+    "first_name": "ioijoi",
+    "middle_names": "jio",
+    "last_name": "oiiooi",
+    "birth_day": 6,
+    "birth_month": 6,
+    "birth_year": 1998,
+    "relationship": "oijio",
+    "dbs_certificate_number": "123456654321",
+    "permission_declare": true
+  }
+},
+{
+  "model": "application.adultinhome",
+  "pk": "2b68b4ff-b3f8-45fa-aa32-e5bac0422f92",
+  "fields": {
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "adult": 1,
+    "first_name": "oijoij",
+    "middle_names": "oijoijioj",
+    "last_name": "oijoij",
+    "birth_day": 6,
+    "birth_month": 6,
+    "birth_year": 1997,
+    "relationship": "lij",
+    "dbs_certificate_number": "123456654321",
+    "permission_declare": true
+  }
+},
+{
+  "model": "application.adultinhome",
+  "pk": "e054518a-0227-4641-a849-1caa8272a06c",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "adult": 1,
+    "first_name": "oijioj",
+    "middle_names": "oijoijoioij",
+    "last_name": "oijoijojioji",
+    "birth_day": 6,
+    "birth_month": 8,
+    "birth_year": 1997,
+    "relationship": "kjkjkj",
+    "dbs_certificate_number": "123456654321",
+    "permission_declare": true
   }
 },
 {
   "model": "application.applicantpersonaldetails",
-  "pk": "434fe670-cba7-4b02-aad7-d50ae67aea1f",
+  "pk": "195fee2c-ff89-473e-9936-fcc4696941c1",
   "fields": {
-    "application_id": "dff7d296-4af8-4b51-8aa5-34802c026644",
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "birth_day": 6,
+    "birth_month": 8,
+    "birth_year": 1997
+  }
+},
+{
+  "model": "application.applicantpersonaldetails",
+  "pk": "29b3a742-b4c9-49d6-be24-774fd65e2f68",
+  "fields": {
+    "application_id": "913092e3-2ff5-4a4f-82ce-18d69badd56e",
     "birth_day": 22,
     "birth_month": 1,
     "birth_year": 1991
   }
 },
 {
-  "model": "application.applicantname",
-  "pk": "c1eed458-045d-4c3f-ae06-3aaa5c287061",
+  "model": "application.applicantpersonaldetails",
+  "pk": "4af69e99-5a13-4739-b01d-5a00923cd2b3",
   "fields": {
-    "personal_detail_id": "434fe670-cba7-4b02-aad7-d50ae67aea1f",
-    "current_name": true,
-    "first_name": "James",
-    "middle_names": "",
-    "last_name": "Cruddas"
+    "application_id": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+    "birth_day": 6,
+    "birth_month": 8,
+    "birth_year": 1997
+  }
+},
+{
+  "model": "application.applicantpersonaldetails",
+  "pk": "8321381b-c739-40f2-acc0-e36eee3a9b2d",
+  "fields": {
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "birth_day": 6,
+    "birth_month": 8,
+    "birth_year": 1997
+  }
+},
+{
+  "model": "application.applicantpersonaldetails",
+  "pk": "8cc0d190-2ab0-4595-88e0-a39e4dd5d24d",
+  "fields": {
+    "application_id": "27f25bec-677e-40b5-adc2-0c0f8a7c62d6",
+    "birth_day": 6,
+    "birth_month": 8,
+    "birth_year": 1997
   }
 },
 {
   "model": "application.applicanthomeaddress",
-  "pk": "94620c78-951f-4d2e-8caa-5e8dfeaeb104",
+  "pk": "1b7da465-8d2d-4fa8-bc43-529863fccf38",
   "fields": {
-    "personal_detail_id": "434fe670-cba7-4b02-aad7-d50ae67aea1f",
+    "personal_detail_id": "8321381b-c739-40f2-acc0-e36eee3a9b2d",
+    "street_line1": "9 Falmouth Close",
+    "street_line2": "",
+    "town": "Macclesfield",
+    "county": "Cheshire",
+    "country": "",
+    "postcode": "SK10 3NS",
+    "childcare_address": true,
+    "current_address": false,
+    "move_in_month": 0,
+    "move_in_year": 0
+  }
+},
+{
+  "model": "application.applicanthomeaddress",
+  "pk": "3cec8113-cb21-4af8-b1d7-a5fcaa20223d",
+  "fields": {
+    "personal_detail_id": "8321381b-c739-40f2-acc0-e36eee3a9b2d",
+    "street_line1": "8 Falmouth Close",
+    "street_line2": "",
+    "town": "Macclesfield",
+    "county": "Cheshire",
+    "country": "United Kingdom",
+    "postcode": "SK10 3NS",
+    "childcare_address": false,
+    "current_address": true,
+    "move_in_month": 0,
+    "move_in_year": 0
+  }
+},
+{
+  "model": "application.applicanthomeaddress",
+  "pk": "94e49580-ad0b-4804-8156-4683d1df53e0",
+  "fields": {
+    "personal_detail_id": "29b3a742-b4c9-49d6-be24-774fd65e2f68",
     "street_line1": "INFORMED SOLUTIONS LTD, THE OLD BANK",
     "street_line2": " OLD MARKET PLACE",
     "town": "ALTRINCHAM",
@@ -197,10 +581,516 @@
   }
 },
 {
-  "model": "application.firstaidtraining",
-  "pk": "ae00972a-24aa-4351-9083-e8b4ba566560",
+  "model": "application.applicanthomeaddress",
+  "pk": "a1d4b6ff-be75-41dc-a5b3-94b784c04130",
   "fields": {
-    "application_id": "dff7d296-4af8-4b51-8aa5-34802c026644",
+    "personal_detail_id": "4af69e99-5a13-4739-b01d-5a00923cd2b3",
+    "street_line1": "uifyew, ifewy",
+    "street_line2": "ifewy",
+    "town": "rewygi",
+    "county": "feiu",
+    "country": "United Kingdom",
+    "postcode": "SK10 3NS",
+    "childcare_address": true,
+    "current_address": true,
+    "move_in_month": 0,
+    "move_in_year": 0
+  }
+},
+{
+  "model": "application.applicanthomeaddress",
+  "pk": "de9b195a-1c49-4f95-9566-29a67fde7940",
+  "fields": {
+    "personal_detail_id": "195fee2c-ff89-473e-9936-fcc4696941c1",
+    "street_line1": ";OUJHOJO",
+    "street_line2": "IJOIJOIJO",
+    "town": "JOJOJOJOI",
+    "county": "JOJOJ",
+    "country": "",
+    "postcode": "SK10 3NS",
+    "childcare_address": true,
+    "current_address": true,
+    "move_in_month": 0,
+    "move_in_year": 0
+  }
+},
+{
+  "model": "application.applicanthomeaddress",
+  "pk": "ecbee176-3e2e-425a-846f-3aaaa5a89552",
+  "fields": {
+    "personal_detail_id": "8cc0d190-2ab0-4595-88e0-a39e4dd5d24d",
+    "street_line1": "oijiooijj",
+    "street_line2": "oijoijoioi",
+    "town": "joijoj",
+    "county": "joijojjoi",
+    "country": "United Kingdom",
+    "postcode": "SK10 3NS",
+    "childcare_address": true,
+    "current_address": true,
+    "move_in_month": 0,
+    "move_in_year": 0
+  }
+},
+{
+  "model": "application.applicantname",
+  "pk": "0cef3e47-0a40-4a7e-874f-6a1707b52d60",
+  "fields": {
+    "personal_detail_id": "8cc0d190-2ab0-4595-88e0-a39e4dd5d24d",
+    "current_name": true,
+    "first_name": "hiuh",
+    "middle_names": "iuhiuhi",
+    "last_name": "iji"
+  }
+},
+{
+  "model": "application.applicantname",
+  "pk": "18a2ca36-aa67-4c5d-9985-962dcd5c2763",
+  "fields": {
+    "personal_detail_id": "29b3a742-b4c9-49d6-be24-774fd65e2f68",
+    "current_name": true,
+    "first_name": "James",
+    "middle_names": "",
+    "last_name": "Cruddas"
+  }
+},
+{
+  "model": "application.applicantname",
+  "pk": "28879d08-f39b-4b15-aba9-006b75d5e876",
+  "fields": {
+    "personal_detail_id": "8321381b-c739-40f2-acc0-e36eee3a9b2d",
+    "current_name": true,
+    "first_name": "Hugo",
+    "middle_names": "Alan",
+    "last_name": "Geeves"
+  }
+},
+{
+  "model": "application.applicantname",
+  "pk": "8268ea35-dcca-4c9c-adfc-249230be47fc",
+  "fields": {
+    "personal_detail_id": "4af69e99-5a13-4739-b01d-5a00923cd2b3",
+    "current_name": true,
+    "first_name": "oiuhjiuhiuhiu",
+    "middle_names": "hiuhiuhi",
+    "last_name": "hiuhuih"
+  }
+},
+{
+  "model": "application.applicantname",
+  "pk": "fc9b75d6-62e4-4744-976d-db54003f38fa",
+  "fields": {
+    "personal_detail_id": "195fee2c-ff89-473e-9936-fcc4696941c1",
+    "current_name": true,
+    "first_name": "liuhLIUHLIUh",
+    "middle_names": "lluihuihl",
+    "last_name": "ihliuh"
+  }
+},
+{
+  "model": "application.arc",
+  "pk": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+  "fields": {
+    "user_id": "",
+    "last_accessed": "26/03/2018",
+    "app_type": "Childminder",
+    "comments": "woijofie",
+    "login_details_review": "FLAGGED",
+    "childcare_type_review": "COMPLETED",
+    "personal_details_review": "FLAGGED",
+    "first_aid_review": "FLAGGED",
+    "dbs_review": "FLAGGED",
+    "health_review": "COMPLETED",
+    "references_review": "FLAGGED",
+    "people_in_home_review": "FLAGGED"
+  }
+},
+{
+  "model": "application.arc",
+  "pk": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+  "fields": {
+    "user_id": "",
+    "last_accessed": "26/03/2018",
+    "app_type": "Childminder",
+    "comments": "No",
+    "login_details_review": "FLAGGED",
+    "childcare_type_review": "COMPLETED",
+    "personal_details_review": "FLAGGED",
+    "first_aid_review": "FLAGGED",
+    "dbs_review": "FLAGGED",
+    "health_review": "COMPLETED",
+    "references_review": "FLAGGED",
+    "people_in_home_review": "FLAGGED"
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 1,
+  "fields": {
+    "table_pk": "fc9b75d6-62e4-4744-976d-db54003f38fa",
+    "table_name": "APPLICANT_NAME",
+    "field_name": "name",
+    "comment": "test",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 2,
+  "fields": {
+    "table_pk": "47e22c31-f301-490f-9ad3-16c10cf234a4",
+    "table_name": "USER_DETAILS",
+    "field_name": "mobile_number",
+    "comment": "Mobile number is wrong",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 3,
+  "fields": {
+    "table_pk": "47e22c31-f301-490f-9ad3-16c10cf234a4",
+    "table_name": "USER_DETAILS",
+    "field_name": "security_question",
+    "comment": "Knowledge is wrong",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 4,
+  "fields": {
+    "table_pk": "28879d08-f39b-4b15-aba9-006b75d5e876",
+    "table_name": "APPLICANT_NAME",
+    "field_name": "name",
+    "comment": "Name test error",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 5,
+  "fields": {
+    "table_pk": "3cec8113-cb21-4af8-b1d7-a5fcaa20223d",
+    "table_name": "APPLICANT_HOME_ADDRESS",
+    "field_name": "childcare_location",
+    "comment": "Childcare location error",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 6,
+  "fields": {
+    "table_pk": "4ff4a2a7-0840-4f54-a907-9f0034d7056e",
+    "table_name": "FIRST_AID_TRAINING",
+    "field_name": "course_date",
+    "comment": "Training error",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 7,
+  "fields": {
+    "table_pk": "7b0725fd-0a0a-49ca-abce-8a724bea15f7",
+    "table_name": "CRIMINAL_RECORD_CHECK",
+    "field_name": "dbs_certificate_number",
+    "comment": "DBS error",
+    "flagged": false
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 8,
+  "fields": {
+    "table_pk": "3f08e902-9647-4900-b2ad-3b856b9bf209",
+    "table_name": "REFERENCE",
+    "field_name": "full_name",
+    "comment": "First reference error",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 9,
+  "fields": {
+    "table_pk": "50cfeb8d-4fd9-4d9d-92fd-c56bfb3fa6a7",
+    "table_name": "REFERENCE",
+    "field_name": "address",
+    "comment": "Second reference error",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 10,
+  "fields": {
+    "table_pk": "72806185-34c6-4485-833e-084d8911b376",
+    "table_name": "CHILD_IN_HOME",
+    "field_name": "full_name",
+    "comment": "Child error",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 11,
+  "fields": {
+    "table_pk": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "table_name": "APPLICATION",
+    "field_name": "adults_in_home",
+    "comment": "People error",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 12,
+  "fields": {
+    "table_pk": "317983ce-8159-41e0-b2cc-09bef17e2ffe",
+    "table_name": "USER_DETAILS",
+    "field_name": "mobile_number",
+    "comment": "Your mobile number is incorrect",
+    "flagged": false
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 13,
+  "fields": {
+    "table_pk": "a1d4b6ff-be75-41dc-a5b3-94b784c04130",
+    "table_name": "APPLICANT_HOME_ADDRESS",
+    "field_name": "home_address",
+    "comment": "Your home address is incorrect",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 14,
+  "fields": {
+    "table_pk": "117f1ac1-632f-4cbf-8543-7d062532f885",
+    "table_name": "FIRST_AID_TRAINING",
+    "field_name": "course_date",
+    "comment": "Your date is incorrect",
+    "flagged": true
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 15,
+  "fields": {
+    "table_pk": "a0cb9791-9c09-4788-bb94-dce2a4e210f2",
+    "table_name": "CRIMINAL_RECORD_CHECK",
+    "field_name": "dbs_certificate_number",
+    "comment": "This is a bad number",
+    "flagged": false
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 16,
+  "fields": {
+    "table_pk": "e717512b-8b20-4b9d-908f-efc8a105c4eb",
+    "table_name": "REFERENCE",
+    "field_name": "email_address",
+    "comment": "Second reference email is the same as the first",
+    "flagged": false
+  }
+},
+{
+  "model": "application.arccomments",
+  "pk": 17,
+  "fields": {
+    "table_pk": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+    "table_name": "APPLICATION",
+    "field_name": "adults_in_home",
+    "comment": "Good",
+    "flagged": true
+  }
+},
+{
+  "model": "application.childinhome",
+  "pk": "38b0f145-f749-48f2-9d6c-0b853c69c74f",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "child": 1,
+    "first_name": "lijj",
+    "middle_names": "oijoijj",
+    "last_name": "oiojoij",
+    "birth_day": 5,
+    "birth_month": 5,
+    "birth_year": 2016,
+    "relationship": "lij"
+  }
+},
+{
+  "model": "application.childinhome",
+  "pk": "72806185-34c6-4485-833e-084d8911b376",
+  "fields": {
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "child": 1,
+    "first_name": "qqq",
+    "middle_names": "qqq",
+    "last_name": "qqq",
+    "birth_day": 8,
+    "birth_month": 8,
+    "birth_year": 2007,
+    "relationship": "iuhiu"
+  }
+},
+{
+  "model": "application.childinhome",
+  "pk": "7467bdce-deda-4485-b3f4-6919cbba838f",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "child": 2,
+    "first_name": "popo",
+    "middle_names": "popo",
+    "last_name": "opopopop",
+    "birth_day": 5,
+    "birth_month": 5,
+    "birth_year": 2017,
+    "relationship": "oiuhhu"
+  }
+},
+{
+  "model": "application.childcaretype",
+  "pk": "3d0ff456-7a61-4907-ba55-1f8934ac6dc6",
+  "fields": {
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "zero_to_five": true,
+    "five_to_eight": true,
+    "eight_plus": false
+  }
+},
+{
+  "model": "application.childcaretype",
+  "pk": "704124a6-07a2-44b2-a55b-270fe604384b",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "zero_to_five": true,
+    "five_to_eight": true,
+    "eight_plus": false
+  }
+},
+{
+  "model": "application.childcaretype",
+  "pk": "772339ae-c81d-477e-a033-00596857abef",
+  "fields": {
+    "application_id": "27f25bec-677e-40b5-adc2-0c0f8a7c62d6",
+    "zero_to_five": false,
+    "five_to_eight": true,
+    "eight_plus": true
+  }
+},
+{
+  "model": "application.childcaretype",
+  "pk": "813a9d0e-eb6a-4fcb-b93d-3c1f888f8583",
+  "fields": {
+    "application_id": "913092e3-2ff5-4a4f-82ce-18d69badd56e",
+    "zero_to_five": true,
+    "five_to_eight": true,
+    "eight_plus": false
+  }
+},
+{
+  "model": "application.childcaretype",
+  "pk": "8ec3991f-788d-4b9d-a36a-1de033fef3f6",
+  "fields": {
+    "application_id": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+    "zero_to_five": true,
+    "five_to_eight": true,
+    "eight_plus": false
+  }
+},
+{
+  "model": "application.criminalrecordcheck",
+  "pk": "0680dddf-8efa-43a0-8f1c-5f76d17ac545",
+  "fields": {
+    "application_id": "913092e3-2ff5-4a4f-82ce-18d69badd56e",
+    "dbs_certificate_number": "121212121212",
+    "cautions_convictions": false,
+    "send_certificate_declare": null
+  }
+},
+{
+  "model": "application.criminalrecordcheck",
+  "pk": "0b4cc98e-c764-4a50-bc33-d8f1a2b19f89",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "dbs_certificate_number": "123456654321",
+    "cautions_convictions": false,
+    "send_certificate_declare": null
+  }
+},
+{
+  "model": "application.criminalrecordcheck",
+  "pk": "7b0725fd-0a0a-49ca-abce-8a724bea15f7",
+  "fields": {
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "dbs_certificate_number": "123456654321",
+    "cautions_convictions": true,
+    "send_certificate_declare": true
+  }
+},
+{
+  "model": "application.criminalrecordcheck",
+  "pk": "a0cb9791-9c09-4788-bb94-dce2a4e210f2",
+  "fields": {
+    "application_id": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+    "dbs_certificate_number": "123456654321",
+    "cautions_convictions": false,
+    "send_certificate_declare": null
+  }
+},
+{
+  "model": "application.firstaidtraining",
+  "pk": "117f1ac1-632f-4cbf-8543-7d062532f885",
+  "fields": {
+    "application_id": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+    "training_organisation": "oiuhuoih",
+    "course_title": "uihiuhiuh",
+    "course_day": 6,
+    "course_month": 8,
+    "course_year": 2017,
+    "show_certificate": true,
+    "renew_certificate": false
+  }
+},
+{
+  "model": "application.firstaidtraining",
+  "pk": "4ff4a2a7-0840-4f54-a907-9f0034d7056e",
+  "fields": {
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "training_organisation": "St Johns Ambulance",
+    "course_title": "Pediatric First Aid",
+    "course_day": 5,
+    "course_month": 5,
+    "course_year": 2017,
+    "show_certificate": true,
+    "renew_certificate": false
+  }
+},
+{
+  "model": "application.firstaidtraining",
+  "pk": "629e4cdc-68ec-4fc4-a090-fd611c0c596e",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "training_organisation": "afdfsa",
+    "course_title": "asdas",
+    "course_day": 6,
+    "course_month": 4,
+    "course_year": 2015,
+    "show_certificate": false,
+    "renew_certificate": true
+  }
+},
+{
+  "model": "application.firstaidtraining",
+  "pk": "98c4db59-2a48-4191-afa9-5be27c0eac45",
+  "fields": {
+    "application_id": "913092e3-2ff5-4a4f-82ce-18d69badd56e",
     "training_organisation": "JMC Training",
     "course_title": "Test",
     "course_day": 22,
@@ -211,28 +1101,63 @@
   }
 },
 {
-  "model": "application.criminalrecordcheck",
-  "pk": "f4203584-e6a2-4d16-a369-639e9b3a92ba",
+  "model": "application.healthdeclarationbooklet",
+  "pk": "36f61ddf-1ee0-44dd-a7ed-93630002fc72",
   "fields": {
-    "application_id": "dff7d296-4af8-4b51-8aa5-34802c026644",
-    "dbs_certificate_number": "121212121212",
-    "cautions_convictions": false,
-    "send_certificate_declare": null
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "send_hdb_declare": true
   }
 },
 {
   "model": "application.healthdeclarationbooklet",
-  "pk": "789b7c11-b8a6-4b3f-aad2-cc9e7de4ff5a",
+  "pk": "4338e53d-eb96-4e8c-b296-582444e90ec0",
   "fields": {
-    "application_id": "dff7d296-4af8-4b51-8aa5-34802c026644",
+    "application_id": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+    "send_hdb_declare": true
+  }
+},
+{
+  "model": "application.healthdeclarationbooklet",
+  "pk": "48221fb3-07c6-4b2e-bca0-037315d72eb5",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "send_hdb_declare": true
+  }
+},
+{
+  "model": "application.healthdeclarationbooklet",
+  "pk": "69df4e68-44cb-4cea-bb3c-09f1b5c2f7ec",
+  "fields": {
+    "application_id": "913092e3-2ff5-4a4f-82ce-18d69badd56e",
     "send_hdb_declare": true
   }
 },
 {
   "model": "application.reference",
-  "pk": "7535f7b1-7eef-4a89-9993-3f0efef57f31",
+  "pk": "02dc352a-bc6a-49e9-8df0-0c3c49ef735e",
   "fields": {
-    "application_id": "dff7d296-4af8-4b51-8aa5-34802c026644",
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "reference": 2,
+    "first_name": "pokpk",
+    "last_name": "opkpokpo",
+    "relationship": "pokpokpok",
+    "years_known": 5,
+    "months_known": 5,
+    "street_line1": "uiyghyug",
+    "street_line2": "uygyuuyg",
+    "town": "uygyuguyg",
+    "county": "yuguyg",
+    "country": "United Kingdom",
+    "postcode": "SK10 3NS",
+    "phone_number": "07864647894",
+    "email": "cheese@cheese.com"
+  }
+},
+{
+  "model": "application.reference",
+  "pk": "2e4d540d-8ebf-4330-907e-00fc27aeecac",
+  "fields": {
+    "application_id": "913092e3-2ff5-4a4f-82ce-18d69badd56e",
     "reference": 2,
     "first_name": "Test",
     "last_name": "User",
@@ -251,9 +1176,93 @@
 },
 {
   "model": "application.reference",
-  "pk": "d807d9b2-010b-47f5-8321-b0864daee6e3",
+  "pk": "3f08e902-9647-4900-b2ad-3b856b9bf209",
   "fields": {
-    "application_id": "dff7d296-4af8-4b51-8aa5-34802c026644",
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "reference": 1,
+    "first_name": "Hugo",
+    "last_name": "Geeves",
+    "relationship": "Myself",
+    "years_known": 6,
+    "months_known": 6,
+    "street_line1": "uwojojoi",
+    "street_line2": "joijoijoj",
+    "town": "oijojoij",
+    "county": "ojoijio",
+    "country": "United Kingdom",
+    "postcode": "SK10 3NS",
+    "phone_number": "07864647894",
+    "email": "hugo.geeves@informed.com"
+  }
+},
+{
+  "model": "application.reference",
+  "pk": "50cfeb8d-4fd9-4d9d-92fd-c56bfb3fa6a7",
+  "fields": {
+    "application_id": "b386943e-034d-41ac-8d9d-a3c0d9ce910f",
+    "reference": 2,
+    "first_name": "oijoijo",
+    "last_name": "ijoip[opk",
+    "relationship": "pokopk",
+    "years_known": 4,
+    "months_known": 4,
+    "street_line1": "pokkpkpo;lnm;lnln",
+    "street_line2": "lknkjnlkjnlkjnl",
+    "town": "kjnlkjnlkjnlkj",
+    "county": "nlkjnlkjnkljnlkjn",
+    "country": "United Kingdom",
+    "postcode": "SK10 3NS",
+    "phone_number": "07864647894",
+    "email": "hugo.geeves@informed.com"
+  }
+},
+{
+  "model": "application.reference",
+  "pk": "57a49c18-45e2-4568-b8ad-96cf090e8208",
+  "fields": {
+    "application_id": "ce5ce2f8-98e6-40f4-8b7e-870c8b3c3fa6",
+    "reference": 1,
+    "first_name": "Hugo",
+    "last_name": "Geeves",
+    "relationship": "oijoij",
+    "years_known": 6,
+    "months_known": 6,
+    "street_line1": "oljioi",
+    "street_line2": "oijoij",
+    "town": "oijoij",
+    "county": "oijoij",
+    "country": "oiji",
+    "postcode": "SK10 3NS",
+    "phone_number": "07864647894",
+    "email": "hugo.geeves@informed.com"
+  }
+},
+{
+  "model": "application.reference",
+  "pk": "5ad08ec3-760b-4ec3-a18b-0e0b5e45e6ec",
+  "fields": {
+    "application_id": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+    "reference": 1,
+    "first_name": "oiuhjih",
+    "last_name": "uihuihiu",
+    "relationship": "h",
+    "years_known": 5,
+    "months_known": 5,
+    "street_line1": "ewkjuhjiuo",
+    "street_line2": "hjikhiu",
+    "town": "hiuh",
+    "county": "iuhih",
+    "country": "United Kingdom",
+    "postcode": "SK10 3NS",
+    "phone_number": "07864647894",
+    "email": "hugo.geeves@informed.com"
+  }
+},
+{
+  "model": "application.reference",
+  "pk": "69ecfb23-f5d2-4231-8ec8-b5d9d5500ead",
+  "fields": {
+    "application_id": "913092e3-2ff5-4a4f-82ce-18d69badd56e",
     "reference": 1,
     "first_name": "Test",
     "last_name": "Person",
@@ -268,6 +1277,27 @@
     "postcode": "WA14 4PA",
     "phone_number": "07791618129",
     "email": "james.cruddas@informed.com"
+  }
+},
+{
+  "model": "application.reference",
+  "pk": "e717512b-8b20-4b9d-908f-efc8a105c4eb",
+  "fields": {
+    "application_id": "e3dae12c-4a3e-4c9c-ab27-7b44c3864dc6",
+    "reference": 2,
+    "first_name": "oiuhiuh",
+    "last_name": "iuhiuh",
+    "relationship": "ihiuh",
+    "years_known": 3,
+    "months_known": 3,
+    "street_line1": "oij",
+    "street_line2": "oijo",
+    "town": "ijoj",
+    "county": "ijioj",
+    "country": "iuhiu",
+    "postcode": "SK10 3NS",
+    "phone_number": "07864647894",
+    "email": "hugo.geeves@informed.com"
   }
 }
 ]

--- a/govuk_template/static/stylesheets/base.css
+++ b/govuk_template/static/stylesheets/base.css
@@ -2497,6 +2497,14 @@ div.error-summary ul.error-summary-list {
   font-weight: bold;
 }
 
+.error-container {
+  margin: 0px;
+}
+
+.error-text {
+  padding-left: 10px;
+}
+
 #radio-or {
   clear: both;
   padding-left: 7px;

--- a/govuk_template/static/stylesheets/base.css
+++ b/govuk_template/static/stylesheets/base.css
@@ -2659,9 +2659,16 @@ a.section-link:active {
 }
 
 .summary-column {
+    word-wrap: break-word;
     width: 40%;
+    border-bottom: 1px solid #bfc1c3 !important;
 }
 
+.error-row {
+    padding-left: 10px;
+    border-bottom: none;
+    border-left: 5px solid #b10e1e;
+}
 .find-address-button {
    margin-left: 10px;
 }


### PR DESCRIPTION
## Description

Templates for representing summary pages have been refactored to all load from a single template. Two new data structures (Table and Row) have been created to accomplish this. This should be checked against the sub tickets of CCN3-620 relating to the summary pages.

## Todo's before PR

- [X] Rebase from develop
- [X] Unit tests passed (`make test`)
- [X] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [X] PR description describes the overall goals of PR commits
- [X] Templates been checked with relevant user-story

## Migrations

- [X] Null fields in models specifies default value
- [X] You generated and applied migrations (`make migrate`)
- [X] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [X] Specified reviewers (even if it's yourself)
- [X] Specified assignees (those who'll merge)
- [X] Specified labels
- [X] Specified milestone

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
