### PR TITLE
personal_details.py: Remove status update for personal details task

### DIFF
--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -840,8 +840,6 @@ def personal_details_summary(request):
 
         form = PersonalDetailsSummaryForm()
         application = Application.get_id(app_id=app_id)
-        status.update(app_id,
-                      'personal_details_status', 'COMPLETED')
         variables = {
             'form': form,
             'application_id': app_id,

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -849,6 +849,9 @@ def personal_details_summary(request):
         }
         variables = submit_link_setter(variables, table_list, 'personal_details', app_id)
 
+        if not sum([table.get_error_amount() for table in variables['table_list']]):  # If no errors found.
+            status.update(app_id, 'personal_details_status', 'COMPLETED')
+
         return render(request, 'generic-summary-template.html', variables)
 
     if request.method == 'POST':


### PR DESCRIPTION
## Description

In the GET request of personal_details_summary view, an update is called on the application's personal details status, thereby locking the task despite the existence of outstanding errors. This line has been removed.

## Todo's before PR

- [x] Rebase from develop
- [x] Unit tests passed (`make test`)
- [x] PR naming according our [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assigneses (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [x] Code syntax formatting checked
- [x] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
