### PR TITLE
first_aid.py: Redirect out of date first aid certificates to task list

### DIFF
--- a/application/views/first_aid.py
+++ b/application/views/first_aid.py
@@ -19,7 +19,6 @@ from ..forms import (FirstAidTrainingDeclarationForm,
                      FirstAidTrainingSummaryForm,
                      FirstAidTrainingTrainingForm)
 from ..models import (Application,
-
                       FirstAidTraining)
 
 
@@ -109,7 +108,7 @@ def first_aid_training_details(request):
                 certificate_year, certificate_month, certificate_day)
             today = date.today()
             certificate_date_difference = today - certificate_date
-            certificate_age = certificate_date_difference.days / 365
+            certificate_age = float(certificate_date_difference.days) / 365.  # Must be a float for Python division.
             if certificate_age < 2.5:
                 return HttpResponseRedirect(settings.URL_PREFIX + '/first-aid/certificate?id=' + application_id_local)
             elif 2.5 <= certificate_age < 3:
@@ -234,7 +233,7 @@ def first_aid_training_training(request):
             first_aid_record.save()
             status.update(application_id_local,
                           'first_aid_training_status', 'NOT_STARTED')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/first-aid/check-answers?id=' + application_id_local)
+            return HttpResponseRedirect(settings.URL_PREFIX + '/task-list/?id=' + application_id_local)
         else:
             variables = {
                 'form': form,


### PR DESCRIPTION
## Description

When a user enters a First Aid certificate date that is more than three years old, they are now redirected to the Task list rather than the First Aid summary page.

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
