### PR TITLE
fix/change-email-template-personalisation

### DIFF
--- a/application/views/login/email.py
+++ b/application/views/login/email.py
@@ -11,7 +11,7 @@ from timeline_logger.models import TimelineLog
 from application.views import magic_link
 from ...utils import test_notify, build_url
 from ...forms import ContactEmailForm
-from ...models import UserDetails, Application
+from ...models import UserDetails, Application, ApplicantName
 
 
 class NewUserSignInView(View):
@@ -199,8 +199,10 @@ def update_magic_link(email, app_id):
     if UserDetails.objects.filter(application_id=app_id).exists():
         acc = UserDetails.objects.get(application_id=app_id)
         link = create_account_magic_link(account=acc)
+        first_name = ApplicantName.objects.get(application_id=app_id).first_name
         # Note url has been updated to use the domain set in the settings
         magic_link.magic_link_update_email(email,
+                                           first_name,
                                            str(settings.PUBLIC_APPLICATION_URL) + '/validate/' + link + '?email=' + email)
 
 

--- a/application/views/magic_link.py
+++ b/application/views/magic_link.py
@@ -47,7 +47,7 @@ def magic_link_confirmation_email(email, link_id):
     return send_email(email, personalisation, template_id)
 
 
-def magic_link_update_email(email, link_id):
+def magic_link_update_email(email, first_name, link_id):
     """
     Method to send a magic link email, using notify.py, to update an applicant's email
     :param email: string containing the e-mail address to send the e-mail to
@@ -61,7 +61,8 @@ def magic_link_update_email(email, link_id):
     else:
         print(link_id)
 
-    personalisation = {"link": link_id}
+    personalisation = {"link": link_id,
+                       "first name": first_name}
     template_id = 'c778438a-c3fb-47e0-ad8a-936021abb1c8'
 
     return send_email(email, personalisation, template_id)


### PR DESCRIPTION
## Description

The email template sent to a user wishing to update their email requires a `first name` argument which was not supplied to the `magic_link_update_email` function and hence the email wouldn't be sent. This has now been added.

## Todo's before PR

- [ ] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
