### PR TITLE
Scroll down to new fields when adding a new person in home

### DIFF
--- a/application/templates/other-people-adult-details.html
+++ b/application/templates/other-people-adult-details.html
@@ -21,7 +21,7 @@
 <form method="post" novalidate {% if form.is_multipart %}enctype="multipart/form-data" {% endif %}>
     <div class="form-group">
         {% for form in form_list %}
-        <h2 class="form-title heading-medium">
+        <h2 class="form-title heading-medium" id="person{{form.prefix}}">
             Person {{form.prefix}}
         </h2>
         {{form.as_div}}

--- a/application/templates/other-people-children-details.html
+++ b/application/templates/other-people-children-details.html
@@ -19,7 +19,7 @@
         </h1>
         <p>Please give details of the children you live with.</p>
         {% for form in form_list %}
-        <h2 class="form-title heading-medium">
+        <h2 class="form-title heading-medium" id="person{{form.prefix}}">
             Child {{form.prefix}}
         </h2>
         {{form.as_div}}

--- a/application/views/other_people.py
+++ b/application/views/other_people.py
@@ -254,7 +254,7 @@ def other_people_adult_details(request):
                 add_adult_string = str(add_adult)
                 return HttpResponseRedirect(
                     settings.URL_PREFIX + '/other-people/adult-details?id=' +
-                    application_id_local + '&adults=' + add_adult_string + '&remove=0',
+                    application_id_local + '&adults=' + add_adult_string + '&remove=0#person' + add_adult_string,
                     variables)
             # If there is an invalid form
             elif False in valid_list:
@@ -657,7 +657,7 @@ def other_people_children_details(request):
                 add_child_string = str(add_child)
                 return HttpResponseRedirect(
                     settings.URL_PREFIX + '/other-people/children-details?id=' +
-                    application_id_local + '&children=' + add_child_string + '&remove=0',
+                    application_id_local + '&children=' + add_child_string + '&remove=0#person' + add_child_string,
                     variables)
             # If there is an invalid form
             elif False in valid_list:


### PR DESCRIPTION
## Description

When adding a new adult or child in the home, go to the new set of fields in the page once an 'Add another adult' or 'Add another child' button has been clicked.

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [ ] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [x] Code syntax formatting checked
- [x] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
