### PR TITLE
Fix bug with multiple error fields displaying and no displayed error summary on e-mail page

### DIFF
--- a/application/forms/childminder.py
+++ b/application/forms/childminder.py
@@ -57,7 +57,7 @@ class ChildminderForms(GOVUKForm):
 
         log = None
         if ArcComments.objects.filter(
-                table_pk=self.pk).count() > 0 and field == 'first_name' or 'last_name' or 'middle_names':
+                table_pk=self.pk).count() > 0 and field in ['first_name', 'last_name', 'middle_names']:
 
             if ArcComments.objects.filter(table_pk=self.pk, field_name='name').exists():
                 log = ArcComments.objects.get(table_pk=self.pk, field_name='name')
@@ -96,7 +96,7 @@ class ChildminderForms(GOVUKForm):
         log = None
         # Right now only an address as a whole can be flagged, and the message is repeated for each field
         if ArcComments.objects.filter(table_pk=self.pk).count() > 0:
-            if field == 'street_line1' or 'street_line2' or 'town' or 'county' or 'country' or 'postcode':
+            if field in ['street_line1', 'street_line2', 'town', 'county', 'country', 'postcode']:
 
                 if ArcComments.objects.filter(table_pk=self.pk, field_name='address').exists():
                     log = ArcComments.objects.get(table_pk=self.pk, field_name='address')

--- a/application/views/login/email.py
+++ b/application/views/login/email.py
@@ -71,6 +71,8 @@ class UpdateEmailView(View):
         app_id = request.GET["id"]
         application = Application.objects.get(pk=app_id)
         form = ContactEmailForm()
+        form.field_list = ['email_address']
+        form.pk = UserDetails.objects.get(application_id=application).login_id
         form.check_flag()
 
         if application.application_status == 'FURTHER_INFORMATION':
@@ -106,13 +108,14 @@ class UpdateEmailView(View):
                 return HttpResponseRedirect(redirect_url)
         else:
 
-            if application.application_status == 'FURTHER_INFORMATION':
-                form.error_summary_template_name = 'returned-error-summary.html'
-                form.error_summary_title = 'There was a problem'
-
             return self.render_update_email_template(request, form=form, application=application)
 
     def render_update_email_template(self, request, form, application):
+
+        if application.application_status == 'FURTHER_INFORMATION':
+            form.error_summary_template_name = 'returned-error-summary.html'
+            form.error_summary_title = 'There was a problem'
+
         variables = {
             'form': form,
             'application_id': application.application_id,


### PR DESCRIPTION
## Description

Bug fixes:
- General bug identified in code that must be fixed: multiple error field names displaying in returned error summary due to faulty if statement in check_flag method logic
- Bug related to CCN3-1083: no returned error summary displaying for e-mail page

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## Migrations

- [x] Null fields in models specifies default value
- [x] You generated and applied migrations (`make migrate`)
- [x] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
