### PR TITLE
Remove Ofsted next steps e-mail timestamp sent at submission

### DIFF
--- a/application/views/payment.py
+++ b/application/views/payment.py
@@ -4,7 +4,6 @@ from timeline_logger.models import TimelineLog
 from ..models import (Application)
 from ..models import (CriminalRecordCheck)
 from .. import status
-from datetime import datetime
 
 
 def payment_confirmation(request):

--- a/application/views/payment.py
+++ b/application/views/payment.py
@@ -29,7 +29,6 @@ def payment_confirmation(request):
         application_id=application_id_local)
     status.update(application_id_local, 'declarations_status', 'COMPLETED')
     local_app.application_status = 'SUBMITTED'
-    local_app.ofsted_visit_email_sent = datetime.now()
     local_app.save()
 
     # Payment presents the first true trigger for submission so is logged as submitted at this point


### PR DESCRIPTION
## Description

Remove Ofsted next steps e-mail timestamp sent at submission, as this will be set after ARC review instead (see CCN3-1129 comments)

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
