### PR TITLE
Only allow access to task list once Your personal details task is fully complete

### DIFF
--- a/application/tests/tests_selenium/test_apply_as_a_childminder.py
+++ b/application/tests/tests_selenium/test_apply_as_a_childminder.py
@@ -14,6 +14,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.select import Select
 
 from .selenium_task_executor import SeleniumTaskExecutor
 
@@ -246,6 +247,50 @@ class ApplyAsAChildminder(LiveServerTestCase):
         self.selenium_task_executor.complete_your_login_details(test_email, test_phone_number, test_alt_phone_number)
 
         self.selenium_task_executor.complete_type_of_childcare(True, True, True, True)
+
+        # Try to get to task list
+        self.selenium_task_executor.get_driver().find_element_by_id("proposition-name").click()
+
+        self.assertEqual("Your name",
+                         self.selenium_task_executor.get_driver().title)
+
+        # Partially complete Personal details task
+        self.selenium_task_executor.get_driver().find_element_by_id("id_first_name").send_keys('Test')
+        self.selenium_task_executor.get_driver().find_element_by_id("id_last_name").send_keys('Test')
+        self.selenium_task_executor.get_driver().find_element_by_xpath("//input[@value='Save and continue']").click()
+
+        # Try to get to task list
+        self.selenium_task_executor.get_driver().find_element_by_id("proposition-name").click()
+
+        self.assertEqual("Your name",
+                         self.selenium_task_executor.get_driver().title)
+
+        self.selenium_task_executor.get_driver().find_element_by_xpath("//input[@value='Save and continue']").click()
+
+        # Partially complete Personal details task
+        self.selenium_task_executor.get_driver().find_element_by_id("id_date_of_birth_0").send_keys(20)
+        self.selenium_task_executor.get_driver().find_element_by_id("id_date_of_birth_1").send_keys(12)
+        self.selenium_task_executor.get_driver().find_element_by_id("id_date_of_birth_2").send_keys(1995)
+        self.selenium_task_executor.get_driver().find_element_by_xpath("//input[@value='Save and continue']").click()
+
+        # Try to get to task list
+        self.selenium_task_executor.get_driver().find_element_by_id("proposition-name").click()
+
+        self.assertEqual("Your name",
+                         self.selenium_task_executor.get_driver().title)
+
+        self.selenium_task_executor.get_driver().find_element_by_xpath("//input[@value='Save and continue']").click()
+        self.selenium_task_executor.get_driver().find_element_by_xpath("//input[@value='Save and continue']").click()
+
+        self.selenium_task_executor.get_driver().find_element_by_id("id_postcode").send_keys("WA14 4PA")
+        self.selenium_task_executor.get_driver().find_element_by_name("postcode-search").click()
+
+        # Select matched result
+        self.selenium_task_executor.get_driver().find_element_by_id("id_address").click()
+        Select(self.selenium_task_executor.get_driver().find_element_by_id("id_address")).select_by_visible_text(
+            "INFORMED SOLUTIONS LTD, THE OLD BANK, OLD MARKET PLACE, ALTRINCHAM, WA14 4PA")
+
+        self.selenium_task_executor.get_driver().find_element_by_xpath("//input[@value='Save and continue']").click()
 
         # Try to get to task list
         self.selenium_task_executor.get_driver().find_element_by_id("proposition-name").click()

--- a/application/views/task_list.py
+++ b/application/views/task_list.py
@@ -40,26 +40,15 @@ def task_list(request):
             return HttpResponseRedirect(reverse("Type-Of-Childcare-Guidance-View") + '?id=' + application_id)
 
         personal_details_record = None
+        personal_details_name_record = None
+        personal_details_home_address_record = None
+        personal_details_childcare_address_record = None
 
         try:
             personal_details_record = ApplicantPersonalDetails.objects.get(application_id=application_id)
-        except Exception as e:
-            return HttpResponseRedirect(reverse("Personal-Details-Name-View") + '?id=' + application_id)
-
-        try:
             personal_details_name_record = ApplicantName.objects.get(application_id=application_id)
-        except Exception as e:
-            return HttpResponseRedirect(reverse("Personal-Details-Name-View") + '?id=' + application_id)
-
-        personal_details_home_address_record = None
-
-        try:
             personal_details_home_address_record = ApplicantHomeAddress.objects.get(application_id=application_id,
                                                                                     current_address=True)
-        except Exception as e:
-            return HttpResponseRedirect(reverse("Personal-Details-Name-View") + '?id=' + application_id)
-
-        try:
             personal_details_childcare_address_record = ApplicantHomeAddress.objects.get(application_id=application_id,
                                                                                          childcare_address=True)
         except Exception as e:

--- a/application/views/task_list.py
+++ b/application/views/task_list.py
@@ -13,8 +13,8 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.views.decorators.cache import never_cache
 
-from application.models import (ApplicantName, ApplicantPersonalDetails, Application, ChildcareType, Arc)
-
+from application.models import (ApplicantName, ApplicantPersonalDetails, Application, ChildcareType, Arc,
+                                ApplicantHomeAddress)
 
 # noinspection PyTypeChecker
 from application.utils import can_cancel
@@ -48,6 +48,20 @@ def task_list(request):
 
         try:
             personal_details_name_record = ApplicantName.objects.get(application_id=application_id)
+        except Exception as e:
+            return HttpResponseRedirect(reverse("Personal-Details-Name-View") + '?id=' + application_id)
+
+        personal_details_home_address_record = None
+
+        try:
+            personal_details_home_address_record = ApplicantHomeAddress.objects.get(application_id=application_id,
+                                                                                    current_address=True)
+        except Exception as e:
+            return HttpResponseRedirect(reverse("Personal-Details-Name-View") + '?id=' + application_id)
+
+        try:
+            personal_details_childcare_address_record = ApplicantHomeAddress.objects.get(application_id=application_id,
+                                                                                         childcare_address=True)
         except Exception as e:
             return HttpResponseRedirect(reverse("Personal-Details-Name-View") + '?id=' + application_id)
 
@@ -217,7 +231,8 @@ def task_list(request):
             ]
         }
 
-    if len([task for task in context['tasks'] if task['status'] in ['IN_PROGRESS', 'NOT_STARTED', 'FLAGGED', 'WAITING']]) < 1:
+    if len([task for task in context['tasks'] if
+            task['status'] in ['IN_PROGRESS', 'NOT_STARTED', 'FLAGGED', 'WAITING']]) < 1:
         context['all_complete'] = True
     else:
         context['all_complete'] = False


### PR DESCRIPTION
## Description

Fix for a bug identified by @raghakalakonda during testing of CCN3-1239 on BUILD. Previously, when applicants signed out without completing the Personal details task, they could still access the task list upon sign in. Now applicants can only do this after they have reached the task's summary page and then sign out and back in. The relevant Selenium test has been updated to take this into account.

## Todo's before PR

- [x] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
