### PR TITLE
feat/ccn3-1320/resubmission-email

### DIFF
--- a/application/views/declaration.py
+++ b/application/views/declaration.py
@@ -8,6 +8,7 @@ from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from timeline_logger.models import TimelineLog
 
+from application.views.magic_link import magic_link_resubmission_confirmation_email
 from .. import status
 from ..forms import (DeclarationIntroForm,
                      DeclarationForm,
@@ -348,8 +349,16 @@ def declaration_declaration(request):
                     'updated_list': updated_list
                 }
 
-                clear_arc_flagged_statuses(application_id_local)
+                user_details = UserDetails.objects.get(application_id=application_id_local)
+                applicant_name = ApplicantName.objects.get(application_id=application_id_local)
+                magic_link_resubmission_confirmation_email(
+                    email=user_details.email,
+                    first_name=applicant_name.first_name,
+                    application_reference=application.application_reference,
+                    updated_tasks=updated_list
+                )
 
+                clear_arc_flagged_statuses(application_id_local)
                 status.update(application_id_local, 'declarations_status', 'COMPLETED')
 
                 return render(request, 'payment-confirmation-resubmitted.html', variables)

--- a/application/views/magic_link.py
+++ b/application/views/magic_link.py
@@ -48,6 +48,38 @@ def magic_link_confirmation_email(email, link_id):
     return send_email(email, personalisation, template_id)
 
 
+def magic_link_resubmission_confirmation_email(email, application_reference, first_name, updated_tasks):
+    """
+    Method to send a magic link email, using notify.py, to allow applicant to log in
+    """
+    personalisation = {
+        'ref': application_reference,
+        'firstName': first_name,
+    }
+
+    all_tasks = [
+        'Your sign in details',
+        'Type of childcare',
+        'Your personal details',
+        'First aid training',
+        'Criminal record (DBS) check',
+        'Early years training',
+        'Health declaration booklet',
+        'People in your home',
+        'References'
+    ]
+
+    for task in all_tasks:
+        personalisation[task] = task in updated_tasks
+
+    # Remove parentheses from 'Criminal record (DBS) check' - Notify cannot format such variables.
+    personalisation['Criminal record DBS check'] = personalisation.pop('Criminal record (DBS) check')
+
+    template_id = '6431f727-c49e-4f17-964e-b5595a83e958'
+
+    send_email(email, personalisation, template_id)
+
+
 def magic_link_update_email(email, first_name, link_id):
     """
     Method to send a magic link email, using notify.py, to update an applicant's email


### PR DESCRIPTION
## Description

Added functionality and template for email to be sent upon successful re-submission of a returned application.

## Todo's before PR

- [ ] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
