### PR TITLE
Trello Bug #55: Set task to Done only once details on task summary page are confirmed 

### DIFF
--- a/application/templates/contact-email.html
+++ b/application/templates/contact-email.html
@@ -22,6 +22,5 @@
     {% csrf_token %}
     <input type="submit" class="button" value="Continue" alt='Continue'>
 </form>
-</div>
 
 {% endblock %}

--- a/application/templates/contact-phone.html
+++ b/application/templates/contact-phone.html
@@ -28,6 +28,7 @@
     <input type="hidden" name="id" value="{{application_id}}"/>
     <!-- If applicant has previously completed this task, allow user to return to task list -->
     {% if login_details_status == 'COMPLETED' and childcare_type_status == 'COMPLETED' %}
+    <br>
     {% include 'return-to-list.html' %}
     {% endif %}
 </form>

--- a/application/templates/contact-summary.html
+++ b/application/templates/contact-summary.html
@@ -101,13 +101,12 @@
     </tbody>
 </table>
 
-{% if childcare_type_status == 'COMPLETED' and childcare_type_status == 'COMPLETED' %}
+{% if childcare_type_status == 'COMPLETED' %}
     <form action="{% url 'Task-List-View' %}?id={{application_id}}" method="get">
         <input type="submit" class="button" value="Confirm and continue"/>
         <input type="hidden" value="{{application_id}}" name="id"/>
     </form>
-    {% endif %}
-    {% if childcare_type_status != 'COMPLETED' %}
+{% elif childcare_type_status != 'COMPLETED' %}
     <form action="{% url 'Type-Of-Childcare-Guidance-View' %}?id={{application_id}}" method="get">
         <input type="submit" class="button" value="Confirm and continue"/>
         <input type="hidden" value="{{application_id}}" name="id"/>

--- a/application/templates/generic-summary-template.html
+++ b/application/templates/generic-summary-template.html
@@ -93,9 +93,10 @@
 
 {% endfor %}
 
-<form action="{{ submit_link|default:"/task-list/"}}?id={{application_id}}" method="get">
+<form method="post">
     <input type="submit" class="button" value="Confirm and continue"/>
     <input type="hidden" value="{{application_id}}" name="id"/>
+    {% csrf_token %}
 </form>
 </div>
 

--- a/application/templates/health-summary.html
+++ b/application/templates/health-summary.html
@@ -37,9 +37,10 @@
     </tbody>
 </table>
 
-<form action="{% url 'Task-List-View' %}?id={{application_id}}" method="get">
+<form method="post">
     <input type="submit" class="button" value="Confirm and continue"/>
     <input type="hidden" value="{{application_id}}" name="id"/>
+    {% csrf_token %}
 </form>
 </div>
 

--- a/application/views/childcare_type.py
+++ b/application/views/childcare_type.py
@@ -217,7 +217,6 @@ def overnight_care(request):
             application.save()
 
             reset_declaration(application)
-            status.update(app_id, 'childcare_type_status', 'COMPLETED')
 
         else:
 
@@ -294,6 +293,8 @@ def childcare_type_summary(request):
         if application.childcare_type_status != 'COMPLETED':
             variables['submit_link'] = reverse('Personal-Details-Name-View')
 
+        status.update(app_id, 'childcare_type_status', 'COMPLETED')
+
         return render(request, 'generic-summary-template.html', variables)
 
 
@@ -312,9 +313,8 @@ def local_authority_links(request):
     if request.method == 'POST':
 
         app_id = request.POST["id"]
-        application = Application.get_id(app_id=app_id)
-        if application.childcare_type_status != 'COMPLETED':
-            status.update(app_id, 'childcare_type_status', 'COMPLETED')
+        status.update(app_id, 'childcare_type_status', 'COMPLETED')
+
         if 'Cancel application' in request.POST.keys():
             return HttpResponseRedirect(reverse('CR-Cancel-Application') + '?id=' + app_id)
         else:

--- a/application/views/childcare_type.py
+++ b/application/views/childcare_type.py
@@ -293,9 +293,14 @@ def childcare_type_summary(request):
         if application.childcare_type_status != 'COMPLETED' or application.childcare_type_status != 'FLAGGED':
             variables['submit_link'] = reverse('Personal-Details-Name-View')
 
-        status.update(app_id, 'childcare_type_status', 'COMPLETED')
-
         return render(request, 'generic-summary-template.html', variables)
+
+    if request.method == 'POST':
+
+        application_id_local = request.POST["id"]
+        status.update(application_id_local, 'childcare_type_status', 'COMPLETED')
+
+        return HttpResponseRedirect(reverse('Task-List-View') + '?id=' + application_id_local)
 
 
 def local_authority_links(request):

--- a/application/views/childcare_type.py
+++ b/application/views/childcare_type.py
@@ -290,7 +290,7 @@ def childcare_type_summary(request):
 
         variables = submit_link_setter(variables, table_list, 'personal_details', app_id)
 
-        if application.childcare_type_status != 'COMPLETED':
+        if application.childcare_type_status != 'COMPLETED' or application.childcare_type_status != 'FLAGGED':
             variables['submit_link'] = reverse('Personal-Details-Name-View')
 
         status.update(app_id, 'childcare_type_status', 'COMPLETED')

--- a/application/views/contact_info.py
+++ b/application/views/contact_info.py
@@ -78,7 +78,6 @@ def contact_phone(request):
                 user_details_record = login_contact_logic_add_phone(app_id, add_phone_form)
                 user_details_record.save()
                 application.date_updated = current_date
-                application.login_details_status = 'COMPLETED'
                 application.save()
                 reset_declaration(application)
 
@@ -119,9 +118,6 @@ def contact_summary(request):
         email = user_details.email
         mobile_number = user_details.mobile_number
         add_phone_number = user_details.add_phone_number
-
-        if application.login_details_status != 'COMPLETED':
-            status.update(app_id, 'login_details_status', 'COMPLETED')
 
         contact_info_fields = collections.OrderedDict([
             ('email_address', email),

--- a/application/views/contact_info.py
+++ b/application/views/contact_info.py
@@ -147,7 +147,13 @@ def contact_summary(request):
 
         variables = submit_link_setter(variables, table_list, 'login_details', app_id)
 
-        variables['submit_link'] = reverse('Type-Of-Childcare-Guidance-View')
+        if application.childcare_type_status == 'COMPLETED' or application.childcare_type_status == 'FLAGGED':
+            variables['submit_link'] = reverse('Task-List-View')
+
+        elif application.childcare_type_status != 'COMPLETED':
+
+            variables['submit_link'] = reverse('Type-Of-Childcare-Guidance-View')
+
         if 'f' in request.GET:
             return render(request, 'no-link-summary-template.html', variables)
         else:
@@ -161,7 +167,14 @@ def contact_summary(request):
 
         if form.is_valid():
             status.update(app_id, 'login_details_status', 'COMPLETED')
-            return HttpResponseRedirect(reverse('Type-Of-Childcare-Guidance-View') + '?id=' + app_id)
+
+            if application.childcare_type_status == 'COMPLETED' or application.childcare_type_status == 'FLAGGED':
+
+                return HttpResponseRedirect(reverse('Task-List-View') + '?id=' + app_id)
+
+            elif application.childcare_type_status != 'COMPLETED':
+
+                return HttpResponseRedirect(reverse('Type-Of-Childcare-Guidance-View') + '?id=' + app_id)
 
         variables = {
             'form': form,

--- a/application/views/dbs.py
+++ b/application/views/dbs.py
@@ -99,8 +99,6 @@ def dbs_check_dbs_details(request):
                 return HttpResponseRedirect(
                     settings.URL_PREFIX + '/criminal-record/post-certificate?id=' + application_id_local)
             elif cautions_convictions == 'False':
-                application.criminal_record_check_status = 'COMPLETED'
-                application.save()
                 return HttpResponseRedirect(
                     settings.URL_PREFIX + '/criminal-record/check-answers?id=' + application_id_local)
         else:
@@ -124,7 +122,7 @@ def dbs_check_upload_dbs(request):
     :param request: a request object used to generate the HttpResponse
     :return: an HttpResponse object with the rendered Your criminal record (DBS) check: upload DBS template
     """
-    current_date = timezone.now()
+
     if request.method == 'GET':
         application_id_local = request.GET["id"]
         form = DBSCheckUploadDBSForm()
@@ -145,8 +143,6 @@ def dbs_check_upload_dbs(request):
         form = DBSCheckUploadDBSForm(request.POST)
         application = Application.objects.get(pk=application_id_local)
         if form.is_valid():
-            application.criminal_record_check_status = 'COMPLETED'
-            application.save()
             return HttpResponseRedirect(
                 settings.URL_PREFIX + '/criminal-record/check-answers?id=' + application_id_local)
         else:
@@ -204,6 +200,7 @@ def dbs_check_summary(request):
         application = Application.objects.get(pk=application_id_local)
         form = DBSCheckSummaryForm(request.POST)
         if form.is_valid():
+            status.update(application_id_local, 'criminal_record_check_status', 'COMPLETED')
             return HttpResponseRedirect(settings.URL_PREFIX + '/task-list?id=' + application_id_local)
         else:
 

--- a/application/views/dbs.py
+++ b/application/views/dbs.py
@@ -192,19 +192,6 @@ def dbs_check_summary(request):
     if request.method == 'POST':
 
         application_id_local = request.POST["id"]
-        application = Application.objects.get(pk=application_id_local)
-        form = DBSCheckSummaryForm(request.POST)
-        if form.is_valid():
-            status.update(application_id_local, 'criminal_record_check_status', 'COMPLETED')
-            return HttpResponseRedirect(reverse('Task-List-View') + '?id=' + application_id_local)
-        else:
+        status.update(application_id_local, 'criminal_record_check_status', 'COMPLETED')
 
-            if application.application_status == 'FURTHER_INFORMATION':
-                form.error_summary_template_name = 'returned-error-summary.html'
-                form.error_summary_title = 'There was a problem'
-
-            variables = {
-                'form': form,
-                'application_id': application_id_local
-            }
-            return render(request, 'dbs-check-summary.html', variables)
+        return HttpResponseRedirect(reverse('Task-List-View') + '?id=' + application_id_local)

--- a/application/views/dbs.py
+++ b/application/views/dbs.py
@@ -3,9 +3,9 @@ from django.utils import timezone
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.core.urlresolvers import reverse
 
 from ..summary_page_data import dbs_summary_dict
-import collections
 from ..table_util import table_creator, submit_link_setter
 from .. import status
 from ..business_logic import (dbs_check_logic,
@@ -41,10 +41,8 @@ def dbs_check_guidance(request):
         application = Application.objects.get(pk=application_id_local)
         if form.is_valid():
             if application.criminal_record_check_status != 'COMPLETED':
-                status.update(application_id_local,
-                              'criminal_record_check_status', 'IN_PROGRESS')
-            return HttpResponseRedirect(
-                settings.URL_PREFIX + '/criminal-record/your-details?id=' + application_id_local)
+                status.update(application_id_local, 'criminal_record_check_status', 'IN_PROGRESS')
+            return HttpResponseRedirect(reverse('DBS-Check-DBS-Details-View') + '?id=' + application_id_local)
         else:
             variables = {
                 'form': form,
@@ -96,11 +94,9 @@ def dbs_check_dbs_details(request):
             reset_declaration(application)
             cautions_convictions = form.cleaned_data['cautions_convictions']
             if cautions_convictions == 'True':
-                return HttpResponseRedirect(
-                    settings.URL_PREFIX + '/criminal-record/post-certificate?id=' + application_id_local)
+                return HttpResponseRedirect(reverse('DBS-Check-Upload-DBS-View') + '?id=' + application_id_local)
             elif cautions_convictions == 'False':
-                return HttpResponseRedirect(
-                    settings.URL_PREFIX + '/criminal-record/check-answers?id=' + application_id_local)
+                return HttpResponseRedirect(reverse('DBS-Check-Summary-View') + '?id=' + application_id_local)
         else:
             form.error_summary_title = 'There was a problem with the DBS details'
 
@@ -143,8 +139,7 @@ def dbs_check_upload_dbs(request):
         form = DBSCheckUploadDBSForm(request.POST)
         application = Application.objects.get(pk=application_id_local)
         if form.is_valid():
-            return HttpResponseRedirect(
-                settings.URL_PREFIX + '/criminal-record/check-answers?id=' + application_id_local)
+            return HttpResponseRedirect(reverse('DBS-Check-Summary-View') + '?id=' + application_id_local)
         else:
 
             form.error_summary_title = 'There was a problem'
@@ -201,7 +196,7 @@ def dbs_check_summary(request):
         form = DBSCheckSummaryForm(request.POST)
         if form.is_valid():
             status.update(application_id_local, 'criminal_record_check_status', 'COMPLETED')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/task-list?id=' + application_id_local)
+            return HttpResponseRedirect(reverse('Task-List-View') + '?id=' + application_id_local)
         else:
 
             if application.application_status == 'FURTHER_INFORMATION':

--- a/application/views/declaration.py
+++ b/application/views/declaration.py
@@ -4,7 +4,7 @@ import calendar
 
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.shortcuts import render
+from django.shortcuts import render, reverse
 from django.views.decorators.cache import never_cache
 from timeline_logger.models import TimelineLog
 
@@ -21,7 +21,6 @@ from ..models import (AdultInHome,
                       ChildInHome,
                       ChildcareType,
                       CriminalRecordCheck,
-                      HealthDeclarationBooklet,
                       EYFS,
                       FirstAidTraining,
                       Reference,
@@ -207,8 +206,7 @@ def declaration_summary(request, print=False):
             'print': print
         }
         if application.declarations_status != 'COMPLETED':
-            status.update(application_id_local,
-                          'declarations_status', 'NOT_STARTED')
+            status.update(application_id_local, 'declarations_status', 'NOT_STARTED')
         if print:
             return variables
         return render(request, 'master-summary.html', variables)
@@ -218,9 +216,8 @@ def declaration_summary(request, print=False):
         application = Application.objects.get(pk=application_id_local)
         if form.is_valid():
             if application.declarations_status != 'COMPLETED':
-                status.update(application_id_local,
-                              'declarations_status', 'IN_PROGRESS')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/declaration/declaration?id=' + application_id_local)
+                status.update(application_id_local, 'declarations_status', 'IN_PROGRESS')
+            return HttpResponseRedirect(reverse('Declaration-Intro-View') + '?id=' + application_id_local)
         else:
             variables = {
                 'form': form,
@@ -251,7 +248,7 @@ def declaration_intro(request):
         application = Application.objects.get(application_id=application_id_local)
         form = DeclarationIntroForm(request.POST)
         if form.is_valid():
-            return HttpResponseRedirect(settings.URL_PREFIX + '/your-declaration?id=' + application_id_local)
+            return HttpResponseRedirect(reverse('Declaration-Declaration-View') + '?id=' + application_id_local)
         else:
             variables = {
                 'form': form,

--- a/application/views/other_people.py
+++ b/application/views/other_people.py
@@ -803,7 +803,6 @@ def other_people_summary(request):
                     [adult.email_resent_timestamp is None for adult in adults_list]):
                 variables['submit_link'] = reverse('Other-People-Email-Confirmation-View')
             elif application.adults_in_home is False:
-                status.update(application_id_local, 'people_in_home_status', 'COMPLETED')
                 variables['submit_link'] = reverse('Task-List-View')
 
             return render(request, 'generic-summary-template.html', variables)

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render, reverse
 
 from ..table_util import Table, create_tables, submit_link_setter
-from .. summary_page_data import personal_details_name_dict, personal_details_link_dict
+from ..summary_page_data import personal_details_name_dict, personal_details_link_dict
 from .. import address_helper, status
 from ..business_logic import (multiple_childcare_address_logic,
                               personal_dob_logic,
@@ -60,7 +60,7 @@ def personal_details_guidance(request):
             if Application.get_id(app_id=app_id).personal_details_status != 'COMPLETED':
                 status.update(app_id, 'personal_details_status', 'IN_PROGRESS')
 
-            return HttpResponseRedirect(settings.URL_PREFIX + '/personal-details/your-name?id=' + app_id)
+            return HttpResponseRedirect(reverse('Personal-Details-Name-View') + '?id=' + app_id)
 
         variables = {
             'form': form,
@@ -117,15 +117,13 @@ def personal_details_name(request):
                 status.update(app_id, 'personal_details_status', 'IN_PROGRESS')
             reset_declaration(application)
 
-            return HttpResponseRedirect(
-                settings.URL_PREFIX + '/personal-details/your-date-of-birth/?id=' + app_id)
+            return HttpResponseRedirect(reverse('Personal-Details-DOB-View') + '?id=' + app_id)
 
         else:
 
             form.error_summary_title = 'There was a problem with your name details'
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -185,14 +183,13 @@ def personal_details_dob(request):
             reset_declaration(application)
 
             return HttpResponseRedirect(
-                settings.URL_PREFIX + '/personal-details/your-home-address?id=' + app_id +
-                '&manual=False&lookup=False')
+                reverse('Personal-Details-Home-Address-View') + '?id=' + app_id + '&manual=False&lookup=False')
+
         else:
 
             form.error_summary_title = 'There was a problem with your date of birth'
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -277,19 +274,16 @@ def personal_details_home_address(request):
                 if Application.get_id(app_id=app_id).personal_details_status != 'COMPLETED':
                     status.update(app_id, 'personal_details_status', 'IN_PROGRESS')
 
-                return HttpResponseRedirect(
-                    settings.URL_PREFIX + '/personal-details/select-home-address/?id=' + app_id)
+                return HttpResponseRedirect(reverse('Personal-Details-Home-Address-Select-View') + '?id=' + app_id)
 
             if 'submit' in request.POST:
-                return HttpResponseRedirect(
-                    settings.URL_PREFIX + '/personal-details/enter-home-address/?id=' + app_id)
+                return HttpResponseRedirect(reverse('Personal-Details-Home-Address-Manual-View') + '?id=' + app_id)
 
         else:
 
             form.error_summary_title = 'There was a problem with your postcode'
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -408,14 +402,12 @@ def personal_details_home_address_select(request):
 
             if Application.get_id(app_id=app_id).personal_details_status != 'COMPLETED':
                 status.update(app_id, 'personal_details_status', 'IN_PROGRESS')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/personal-details/home-address-details?id=' +
-                                        app_id)
+            return HttpResponseRedirect(reverse('Personal-Details-Location-Of-Care-View') + '?id=' + app_id)
         else:
 
             form.error_summary_title = 'There was a problem finding your address'
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -498,8 +490,7 @@ def personal_details_location_of_care(request):
 
             if home_address_record.childcare_address:
 
-                return HttpResponseRedirect(
-                    settings.URL_PREFIX + '/personal-details/check-answers?id=' + app_id)
+                return HttpResponseRedirect(reverse('Personal-Details-Summary-View') + '?id=' + app_id)
 
             else:
 
@@ -509,7 +500,6 @@ def personal_details_location_of_care(request):
             form.error_summary_title = 'There was a problem with your address details'
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -608,23 +598,20 @@ def personal_details_childcare_address(request):
                 if Application.get_id(app_id=app_id).personal_details_status != 'COMPLETED':
                     status.update(app_id, 'personal_details_status', 'IN_PROGRESS')
 
-                return HttpResponseRedirect(settings.URL_PREFIX + '/personal-details/select-childcare-address/?id='
-                                            + app_id)
+                return HttpResponseRedirect(reverse('Personal-Details-Childcare-Address-Select-View') + '?id=' + app_id)
 
             if 'submit' in request.POST:
 
                 if Application.get_id(app_id=app_id).personal_details_status != 'COMPLETED':
                     status.update(app_id, 'personal_details_status', 'IN_PROGRESS')
 
-                return HttpResponseRedirect(settings.URL_PREFIX + '/personal-details/enter-childcare-address/?id='
-                                            + app_id)
+                return HttpResponseRedirect(reverse('Personal-Details-Childcare-Address-Manual-View') + '?id=' + app_id)
 
         else:
 
             form.error_summary_title = 'There was a problem with your postcode'
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -747,14 +734,12 @@ def personal_details_childcare_address_select(request):
             if Application.get_id(app_id=app_id).personal_details_status != 'COMPLETED':
                 status.update(app_id, 'personal_details_status', 'IN_PROGRESS')
 
-            return HttpResponseRedirect(settings.URL_PREFIX + '/personal-details/check-answers?id=' +
-                                        app_id)
+            return HttpResponseRedirect(reverse('Personal-Details-Summary-View') + '?id=' + app_id)
         else:
 
             form.error_summary_title = 'There was a problem finding your address'
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -844,15 +829,13 @@ def personal_details_childcare_address_manual(request):
             if Application.get_id(app_id=app_id).personal_details_status != 'COMPLETED':
                 status.update(app_id, 'personal_details_status', 'IN_PROGRESS')
             reset_declaration(application)
-            return HttpResponseRedirect(
-                settings.URL_PREFIX + '/personal-details/check-answers?id=' + app_id)
+            return HttpResponseRedirect(reverse('Personal-Details-Summary-View') + '?id=' + app_id)
 
         else:
 
             form.error_summary_title = 'There was a problem with your address'
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -963,15 +946,5 @@ def personal_details_summary(request):
     if request.method == 'POST':
 
         app_id = request.POST["id"]
-        form = PersonalDetailsSummaryForm()
-
-        if form.is_valid():
-            status.update(app_id, 'personal_details_status', 'COMPLETED')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/task-list?id=' + app_id)
-
-        else:
-            variables = {
-                'form': form,
-                'application_id': app_id
-            }
-            return render(request, 'personal-details-summary.html', variables)
+        status.update(app_id, 'personal_details_status', 'COMPLETED')
+        return HttpResponseRedirect(reverse('Task-List-View') + '?id=' + app_id)

--- a/application/views/references.py
+++ b/application/views/references.py
@@ -4,10 +4,10 @@ from django.utils import timezone
 
 from django.conf import settings
 from django.http import HttpResponseRedirect
-from django.shortcuts import render
+from django.shortcuts import render, reverse
 
-from ..summary_page_data import first_reference_name_dict, first_reference_link_dict,\
-                                second_reference_name_dict, second_reference_link_dict
+from ..summary_page_data import first_reference_name_dict, first_reference_link_dict, \
+    second_reference_name_dict, second_reference_link_dict
 from ..table_util import Table, create_tables, submit_link_setter
 from .. import address_helper, status
 from ..business_logic import (references_first_reference_logic,
@@ -56,9 +56,8 @@ def references_intro(request):
 
         if form.is_valid():
             if application.references_status != 'COMPLETED':
-                status.update(application_id_local,
-                              'references_status', 'IN_PROGRESS')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/first-reference?id=' + application_id_local)
+                status.update(application_id_local, 'references_status', 'IN_PROGRESS')
+            return HttpResponseRedirect(reverse('References-First-Reference-View') + '?id=' + application_id_local)
         else:
             variables = {
                 'form': form,
@@ -108,13 +107,12 @@ def references_first_reference(request):
             application.date_updated = current_date
             application.save()
             reset_declaration(application)
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/first-reference-address?id=' +
-                                        application_id_local)
+            return HttpResponseRedirect(
+                reverse('References-First-Reference-Address-View') + '?id=' + application_id_local)
         else:
             form.error_summary_title = "There was a problem with the referee's details"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -163,16 +161,15 @@ def references_first_reference_address(request):
             application.date_updated = current_date
             application.save()
             if 'postcode-search' in request.POST:
-                return HttpResponseRedirect(settings.URL_PREFIX + '/references/select-first-reference-address/?id='
+                return HttpResponseRedirect(reverse('References-Select-First-Reference-Address-View') + '?id='
                                             + application_id_local)
             if 'submit' in request.POST:
-                return HttpResponseRedirect(settings.URL_PREFIX + '/references/enter-first-reference-address/?id='
+                return HttpResponseRedirect(reverse('References-Enter-First-Reference-Address-View') + '?id='
                                             + application_id_local)
         else:
             form.error_summary_title = "There was a problem with the referee's postcode"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -205,7 +202,6 @@ def references_first_reference_address_select(request):
                 id=application_id_local, choices=addresses)
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -222,7 +218,6 @@ def references_first_reference_address_select(request):
             form.errors['postcode'] = {'Please enter a valid postcode.': 'invalid'}
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -260,13 +255,12 @@ def references_first_reference_address_select(request):
             application.save()
             if Application.objects.get(pk=application_id_local).references_status != 'COMPLETED':
                 status.update(application_id_local, 'references_status', 'IN_PROGRESS')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/first-reference-contact-details?id=' +
+            return HttpResponseRedirect(reverse('References-First-Reference-Contact-Details-View') + '?id=' +
                                         application_id_local)
         else:
             form.error_summary_title = "There was a problem finding the referee's address"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -334,13 +328,12 @@ def references_first_reference_address_manual(request):
             if application.references_status != 'COMPLETED':
                 status.update(application_id_local,
                               'references_status', 'IN_PROGRESS')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/first-reference-contact-details?id=' +
+            return HttpResponseRedirect(reverse('References-First-Reference-Contact-Details-View') + '?id=' +
                                         application_id_local)
         else:
             form.error_summary_title = "There was a problem with the referee's address"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -396,12 +389,11 @@ def references_first_reference_contact_details(request):
             application.date_updated = current_date
             application.save()
             reset_declaration(application)
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/second-reference?id=' + application_id_local)
+            return HttpResponseRedirect(reverse('References-Second-Reference-View') + '?id=' + application_id_local)
         else:
             form.error_summary_title = "There was a problem with the referee's contact details"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -453,13 +445,12 @@ def references_second_reference(request):
             application.date_updated = current_date
             application.save()
             reset_declaration(application)
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/second-reference-address?id=' +
+            return HttpResponseRedirect(reverse('References-Second-Reference-Address-View') + '?id=' +
                                         application_id_local + '&manual=False&lookup=False')
         else:
             form.error_summary_title = "There was a problem with the referee's details"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -508,16 +499,15 @@ def references_second_reference_address(request):
             application.date_updated = current_date
             application.save()
             if 'postcode-search' in request.POST:
-                return HttpResponseRedirect(settings.URL_PREFIX + '/references/select-second-reference-address/?id='
+                return HttpResponseRedirect(reverse('References-Select-Second-Reference-Address-View') + '?id='
                                             + application_id_local)
             if 'submit' in request.POST:
-                return HttpResponseRedirect(settings.URL_PREFIX + '/references/enter-second-reference-address/?id='
+                return HttpResponseRedirect(reverse('References-Enter-Second-Reference-Address-View') + '?id='
                                             + application_id_local)
         else:
             form.error_summary_title = "There was a problem with the referee's postcode"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -550,7 +540,6 @@ def references_second_reference_address_select(request):
                 id=application_id_local, choices=addresses)
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -567,7 +556,6 @@ def references_second_reference_address_select(request):
             form.errors['postcode'] = {'Please enter a valid postcode.': 'invalid'}
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -607,13 +595,12 @@ def references_second_reference_address_select(request):
             if Application.objects.get(pk=application_id_local).references_status != 'COMPLETED':
                 status.update(application_id_local,
                               'references_status', 'IN_PROGRESS')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/second-reference-contact-details?id=' +
+            return HttpResponseRedirect(reverse('References-Second-Reference-Contact-Details-View') + '?id=' +
                                         application_id_local)
         else:
             form.error_summary_title = "There was a problem finding the referee's address"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -680,13 +667,12 @@ def references_second_reference_address_manual(request):
             if application.references_status != 'COMPLETED':
                 status.update(application_id_local,
                               'references_status', 'IN_PROGRESS')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/second-reference-contact-details?id=' +
+            return HttpResponseRedirect(reverse('References-Second-Reference-Contact-Details-View') + '?id=' +
                                         application_id_local)
         else:
             form.error_summary_title = "There was a problem with the referee's address"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -740,12 +726,11 @@ def references_second_reference_contact_details(request):
             application.date_updated = current_date
             application.save()
             reset_declaration(application)
-            return HttpResponseRedirect(settings.URL_PREFIX + '/references/check-answers?id=' + application_id_local)
+            return HttpResponseRedirect(reverse('References-Summary-View') + '?id=' + application_id_local)
         else:
             form.error_summary_title = "There was a problem with the referee's contact details"
 
             if application.application_status == 'FURTHER_INFORMATION':
-
                 form.error_summary_template_name = 'returned-error-summary.html'
                 form.error_summary_title = 'There was a problem'
 
@@ -807,10 +792,10 @@ def references_summary(request):
             ('full_name', ' '.join([first_reference_first_name, first_reference_last_name])),
             ('relationship', first_reference_relationship),
             ('known_for', ' '.join([str(first_reference_years_known), first_years_known_str,
-                                   str(first_reference_months_known), first_months_known_str])),
+                                    str(first_reference_months_known), first_months_known_str])),
             ('address', ' '.join([first_reference_street_line1, (first_reference_street_line2 or ''),
-                                 first_reference_town, (first_reference_county or ''),
-                                 first_reference_postcode, first_reference_country])),
+                                  first_reference_town, (first_reference_county or ''),
+                                  first_reference_postcode, first_reference_country])),
             ('phone_number', first_reference_phone_number),
             ('email_address', first_reference_email)
         ])
@@ -852,14 +837,5 @@ def references_summary(request):
         return render(request, 'generic-summary-template.html', variables)
     if request.method == 'POST':
         application_id_local = request.POST["id"]
-        form = ReferenceSummaryForm()
-        if form.is_valid():
-            status.update(application_id_local,
-                          'references_status', 'COMPLETED')
-            return HttpResponseRedirect(settings.URL_PREFIX + '/task-list?id=' + application_id_local)
-        else:
-            variables = {
-                'form': form,
-                'application_id': application_id_local
-            }
-            return render(request, 'references-summary.html', variables)
+        status.update(application_id_local, 'references_status', 'COMPLETED')
+        return HttpResponseRedirect(reverse('Task-List-View') + '?id=' + application_id_local)

--- a/application/views/task_list.py
+++ b/application/views/task_list.py
@@ -14,7 +14,7 @@ from django.http import HttpResponseRedirect
 from django.views.decorators.cache import never_cache
 
 from ..models import (ApplicantName, ApplicantPersonalDetails, Application, ChildcareType, Arc,
-                                ApplicantHomeAddress)
+                      ApplicantHomeAddress)
 
 # noinspection PyTypeChecker
 from ..utils import can_cancel
@@ -33,197 +33,198 @@ def task_list(request):
     if request.method == 'GET':
 
         application_id = request.GET["id"]
-        application = Application.objects.get(pk=application_id)
 
-        # Add handlers to prevent a user re-accessing their application details and modifying post-submission
-        if application.application_status == 'ARC_REVIEW' or application.application_status == 'SUBMITTED':
-            return HttpResponseRedirect(
-                reverse('Awaiting-Review-View') + '?id=' + str(application.application_id)
-            )
+    application = Application.objects.get(pk=application_id)
 
-        if application.application_status == 'ACCEPTED':
-            return HttpResponseRedirect(
-                reverse('Accepted-View') + '?id=' + str(application.application_id)
-            )
+    # Add handlers to prevent a user re-accessing their application details and modifying post-submission
+    if application.application_status == 'ARC_REVIEW' or application.application_status == 'SUBMITTED':
+        return HttpResponseRedirect(
+            reverse('Awaiting-Review-View') + '?id=' + str(application.application_id)
+        )
 
-        try:
-            childcare_record = ChildcareType.objects.get(application_id=application_id)
+    if application.application_status == 'ACCEPTED':
+        return HttpResponseRedirect(
+            reverse('Accepted-View') + '?id=' + str(application.application_id)
+        )
 
-            # If user is attempting to force navigate to the Task list despite being ineligible
-            # to apply, redirect them back to the cancellation page
-            if not eligible_to_apply_based_on_childcare_ages(childcare_record):
-                return HttpResponseRedirect(reverse('Local-Authority-View') + '?id=' + application_id)
-        except Exception as e:
-            return HttpResponseRedirect(reverse("Type-Of-Childcare-Guidance-View") + '?id=' + application_id)
+    try:
+        childcare_record = ChildcareType.objects.get(application_id=application_id)
 
-        if application.personal_details_status == 'NOT_STARTED':
-            return HttpResponseRedirect(reverse("Personal-Details-Name-View") + '?id=' + application_id)
+        # If user is attempting to force navigate to the Task list despite being ineligible
+        # to apply, redirect them back to the cancellation page
+        if not eligible_to_apply_based_on_childcare_ages(childcare_record):
+            return HttpResponseRedirect(reverse('Local-Authority-View') + '?id=' + application_id)
+    except Exception as e:
+        return HttpResponseRedirect(reverse("Type-Of-Childcare-Guidance-View") + '?id=' + application_id)
 
-        zero_to_five_status = childcare_record.zero_to_five
-        five_to_eight_status = childcare_record.five_to_eight
-        eight_plus_status = childcare_record.eight_plus
+    if application.personal_details_status == 'NOT_STARTED':
+        return HttpResponseRedirect(reverse("Personal-Details-Name-View") + '?id=' + application_id)
 
-        # See childcare_type move to separate method/file
+    zero_to_five_status = childcare_record.zero_to_five
+    five_to_eight_status = childcare_record.five_to_eight
+    eight_plus_status = childcare_record.eight_plus
 
-        if (zero_to_five_status is True) & (five_to_eight_status is True) & (eight_plus_status is True):
-            registers = 'Early Years and Childcare Register (both parts)'
-            fee = '£35'
-        elif (zero_to_five_status is True) & (five_to_eight_status is True) & (eight_plus_status is False):
-            registers = 'Early Years and Childcare Register (compulsory part)'
-            fee = '£35'
-        elif (zero_to_five_status is True) & (five_to_eight_status is False) & (eight_plus_status is True):
-            registers = 'Early Years and Childcare Register (voluntary part)'
-            fee = '£35'
-        elif (zero_to_five_status is False) & (five_to_eight_status is True) & (eight_plus_status is True):
-            registers = 'Childcare Register (both parts)'
-            fee = '£103'
-        elif (zero_to_five_status is True) & (five_to_eight_status is False) & (eight_plus_status is False):
-            registers = 'Early Years Register'
-            fee = '£35'
-        elif (zero_to_five_status is False) & (five_to_eight_status is True) & (eight_plus_status is False):
-            registers = 'Childcare Register (compulsory part)'
-            fee = '£103'
-        elif (zero_to_five_status is False) & (five_to_eight_status is False) & (eight_plus_status is True):
-            registers = 'Childcare Register (voluntary part)'
-            fee = '£103'
+    # See childcare_type move to separate method/file
 
-        """
-        Variables which are passed to the template
-        """
+    if (zero_to_five_status is True) & (five_to_eight_status is True) & (eight_plus_status is True):
+        registers = 'Early Years and Childcare Register (both parts)'
+        fee = '£35'
+    elif (zero_to_five_status is True) & (five_to_eight_status is True) & (eight_plus_status is False):
+        registers = 'Early Years and Childcare Register (compulsory part)'
+        fee = '£35'
+    elif (zero_to_five_status is True) & (five_to_eight_status is False) & (eight_plus_status is True):
+        registers = 'Early Years and Childcare Register (voluntary part)'
+        fee = '£35'
+    elif (zero_to_five_status is False) & (five_to_eight_status is True) & (eight_plus_status is True):
+        registers = 'Childcare Register (both parts)'
+        fee = '£103'
+    elif (zero_to_five_status is True) & (five_to_eight_status is False) & (eight_plus_status is False):
+        registers = 'Early Years Register'
+        fee = '£35'
+    elif (zero_to_five_status is False) & (five_to_eight_status is True) & (eight_plus_status is False):
+        registers = 'Childcare Register (compulsory part)'
+        fee = '£103'
+    elif (zero_to_five_status is False) & (five_to_eight_status is False) & (eight_plus_status is True):
+        registers = 'Childcare Register (voluntary part)'
+        fee = '£103'
 
-        context = {
-            'id': application_id,
-            'all_complete': False,
-            'registers': registers,
-            'fee': fee,
-            'can_cancel': can_cancel(application),
-            'application_status': application.application_status,
-            'tasks': [
-                {
-                    'name': 'account_details',  # This is CSS class (Not recommended to store it here)
-                    'status': application.login_details_status,
-                    'arc_flagged': application.login_details_arc_flagged,
-                    'description': "Your sign in details",
-                    'status_url': None,  # Will be filled later
-                    'status_urls': [  # Available urls for each status
-                        {'status': 'COMPLETED', 'url': 'Contact-Summary-View'},
-                        {'status': 'FLAGGED', 'url': 'Contact-Summary-View'},
-                        {'status': 'OTHER', 'url': 'Contact-Email-View'},  # For all other statuses
-                    ],
-                },
-                {
-                    'name': 'children',
-                    'status': application.childcare_type_status,
-                    'arc_flagged': application.childcare_type_arc_flagged,
-                    'description': "Type of childcare",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'Type-Of-Childcare-Summary-View'},
-                        {'status': 'FLAGGED', 'url': 'Type-Of-Childcare-Summary-View'},
-                        {'status': 'OTHER', 'url': 'Type-Of-Childcare-Guidance-View'}
-                    ],
-                },
-                {
-                    'name': 'personal_details',
-                    'status': application.personal_details_status,
-                    'arc_flagged': application.personal_details_arc_flagged,
-                    'description': "Your personal details",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'Personal-Details-Summary-View'},
-                        {'status': 'FLAGGED', 'url': 'Personal-Details-Summary-View'},
-                        {'status': 'OTHER', 'url': 'Personal-Details-Name-View'}
-                    ],
-                },
-                {
-                    'name': 'first_aid',
-                    'status': application.first_aid_training_status,
-                    'arc_flagged': application.first_aid_training_arc_flagged,
-                    'description': "First aid training",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'First-Aid-Training-Summary-View'},
-                        {'status': 'FLAGGED', 'url': 'First-Aid-Training-Summary-View'},
-                        {'status': 'OTHER', 'url': 'First-Aid-Training-Guidance-View'}
-                    ],
-                },
-                {
-                    'name': 'eyfs',
-                    'status': application.eyfs_training_status,
-                    'arc_flagged': application.eyfs_training_arc_flagged,
-                    'description': "Early years training",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'EYFS-Summary-View'},
-                        {'status': 'FLAGGED', 'url': 'EYFS-Summary-View'},
-                        {'status': 'OTHER', 'url': 'EYFS-Guidance-View'}
-                    ],
-                },
-                {
-                    'name': 'health',
-                    'status': application.health_status,
-                    'arc_flagged': application.health_arc_flagged,
-                    'description': "Health declaration booklet",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'Health-Check-Answers-View'},
-                        {'status': 'FLAGGED', 'url': 'Health-Check-Answers-View'},
-                        {'status': 'OTHER', 'url': 'Health-Intro-View'}
-                    ],
-                },
-                {
-                    'name': 'dbs',
-                    'status': application.criminal_record_check_status,
-                    'arc_flagged': application.criminal_record_check_arc_flagged,
-                    'description': "Criminal record (DBS) check",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'DBS-Check-Summary-View'},
-                        {'status': 'FLAGGED', 'url': 'DBS-Check-Summary-View'},
-                        {'status': 'OTHER', 'url': 'DBS-Check-Guidance-View'}
-                    ],
-                },
-                {
-                    'name': 'other_people',
-                    'status': application.people_in_home_status,
-                    'arc_flagged': application.people_in_home_arc_flagged,
-                    'description': "People in your home",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'Other-People-Summary-View'},
-                        {'status': 'FLAGGED', 'url': 'Other-People-Summary-View'},
-                        {'status': 'WAITING', 'url': 'Other-People-Summary-View'},
-                        {'status': 'OTHER', 'url': 'Other-People-Guidance-View'}
-                    ],
-                },
-                {
-                    'name': 'references',
-                    'status': application.references_status,
-                    'arc_flagged': application.references_arc_flagged,
-                    'description': "References",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'References-Summary-View'},
-                        {'status': 'FLAGGED', 'url': 'References-Summary-View'},
-                        {'status': 'OTHER', 'url': 'References-Intro-View'}
-                    ],
-                },
-                {
-                    'name': 'review',
-                    'status': None,
-                    'arc_flagged': application.application_status,
-                    # If application is being resubmitted (i.e. is not drafting,
-                    # set declaration task name to read "Declaration" only)
-                    'description':
-                        "Declaration and payment" if application.application_status == 'DRAFTING' else "Declaration",
-                    'status_url': None,
-                    'status_urls': [
-                        {'status': 'COMPLETED', 'url': 'Declaration-Declaration-View'},
-                        {'status': 'OTHER', 'url': 'Declaration-Summary-View'}
-                    ],
-                },
-            ]
-        }
+    """
+    Variables which are passed to the template
+    """
+
+    context = {
+        'id': application_id,
+        'all_complete': False,
+        'registers': registers,
+        'fee': fee,
+        'can_cancel': can_cancel(application),
+        'application_status': application.application_status,
+        'tasks': [
+            {
+                'name': 'account_details',  # This is CSS class (Not recommended to store it here)
+                'status': application.login_details_status,
+                'arc_flagged': application.login_details_arc_flagged,
+                'description': "Your sign in details",
+                'status_url': None,  # Will be filled later
+                'status_urls': [  # Available urls for each status
+                    {'status': 'COMPLETED', 'url': 'Contact-Summary-View'},
+                    {'status': 'FLAGGED', 'url': 'Contact-Summary-View'},
+                    {'status': 'OTHER', 'url': 'Contact-Email-View'},  # For all other statuses
+                ],
+            },
+            {
+                'name': 'children',
+                'status': application.childcare_type_status,
+                'arc_flagged': application.childcare_type_arc_flagged,
+                'description': "Type of childcare",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'Type-Of-Childcare-Summary-View'},
+                    {'status': 'FLAGGED', 'url': 'Type-Of-Childcare-Summary-View'},
+                    {'status': 'OTHER', 'url': 'Type-Of-Childcare-Guidance-View'}
+                ],
+            },
+            {
+                'name': 'personal_details',
+                'status': application.personal_details_status,
+                'arc_flagged': application.personal_details_arc_flagged,
+                'description': "Your personal details",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'Personal-Details-Summary-View'},
+                    {'status': 'FLAGGED', 'url': 'Personal-Details-Summary-View'},
+                    {'status': 'OTHER', 'url': 'Personal-Details-Name-View'}
+                ],
+            },
+            {
+                'name': 'first_aid',
+                'status': application.first_aid_training_status,
+                'arc_flagged': application.first_aid_training_arc_flagged,
+                'description': "First aid training",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'First-Aid-Training-Summary-View'},
+                    {'status': 'FLAGGED', 'url': 'First-Aid-Training-Summary-View'},
+                    {'status': 'OTHER', 'url': 'First-Aid-Training-Guidance-View'}
+                ],
+            },
+            {
+                'name': 'eyfs',
+                'status': application.eyfs_training_status,
+                'arc_flagged': application.eyfs_training_arc_flagged,
+                'description': "Early years training",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'EYFS-Summary-View'},
+                    {'status': 'FLAGGED', 'url': 'EYFS-Summary-View'},
+                    {'status': 'OTHER', 'url': 'EYFS-Guidance-View'}
+                ],
+            },
+            {
+                'name': 'health',
+                'status': application.health_status,
+                'arc_flagged': application.health_arc_flagged,
+                'description': "Health declaration booklet",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'Health-Check-Answers-View'},
+                    {'status': 'FLAGGED', 'url': 'Health-Check-Answers-View'},
+                    {'status': 'OTHER', 'url': 'Health-Intro-View'}
+                ],
+            },
+            {
+                'name': 'dbs',
+                'status': application.criminal_record_check_status,
+                'arc_flagged': application.criminal_record_check_arc_flagged,
+                'description': "Criminal record (DBS) check",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'DBS-Check-Summary-View'},
+                    {'status': 'FLAGGED', 'url': 'DBS-Check-Summary-View'},
+                    {'status': 'OTHER', 'url': 'DBS-Check-Guidance-View'}
+                ],
+            },
+            {
+                'name': 'other_people',
+                'status': application.people_in_home_status,
+                'arc_flagged': application.people_in_home_arc_flagged,
+                'description': "People in your home",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'Other-People-Summary-View'},
+                    {'status': 'FLAGGED', 'url': 'Other-People-Summary-View'},
+                    {'status': 'WAITING', 'url': 'Other-People-Summary-View'},
+                    {'status': 'OTHER', 'url': 'Other-People-Guidance-View'}
+                ],
+            },
+            {
+                'name': 'references',
+                'status': application.references_status,
+                'arc_flagged': application.references_arc_flagged,
+                'description': "References",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'References-Summary-View'},
+                    {'status': 'FLAGGED', 'url': 'References-Summary-View'},
+                    {'status': 'OTHER', 'url': 'References-Intro-View'}
+                ],
+            },
+            {
+                'name': 'review',
+                'status': None,
+                'arc_flagged': application.application_status,
+                # If application is being resubmitted (i.e. is not drafting,
+                # set declaration task name to read "Declaration" only)
+                'description':
+                    "Declaration and payment" if application.application_status == 'DRAFTING' else "Declaration",
+                'status_url': None,
+                'status_urls': [
+                    {'status': 'COMPLETED', 'url': 'Declaration-Declaration-View'},
+                    {'status': 'OTHER', 'url': 'Declaration-Summary-View'}
+                ],
+            },
+        ]
+    }
 
     if len([task for task in context['tasks'] if
             task['status'] in ['IN_PROGRESS', 'NOT_STARTED', 'FLAGGED', 'WAITING']]) < 1:


### PR DESCRIPTION
## Description

- Each task should now only be set to Done once the applicant has clicked on Confirm the task's summary page
- Replacement of hard-coded URLs with reverse() statements
- Refactoring of generic summary template and code to access the task list (following confirmation of task details) via a POST instead of a GET request. This allows the task to be set to Done only once the applicant clicks on the Confirm button.

## Todo's before PR

- [ ] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [ ] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
