### PR TITLE
Fix previous URL not being passed to Feedback confirmation page after submitting invalid feedback first

### DIFF
--- a/application/views/feedback.py
+++ b/application/views/feedback.py
@@ -50,7 +50,8 @@ def feedback(request):
         else:
             form.error_summary_title = 'There was a problem'
             variables = {
-                'form': form
+                'form': form,
+                'previous_url': previous_url
             }
 
             return render(request, 'feedback.html', variables)


### PR DESCRIPTION
## Description

The previous URL was not being passed to the Feedback confirmation page after a user tried to submit invalid feedback - this has now been fixed (CCN3-1443)

## Todo's before PR

- [x] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
