### PR TITLE
CCN3-1443 bug fix: URL encoding of previous URL GET parameter

### DIFF
--- a/application/templates/feedback-confirmation.html
+++ b/application/templates/feedback-confirmation.html
@@ -17,7 +17,7 @@
 <form method="post" novalidate {% if form.is_multipart %}enctype="multipart/form-data" {% endif %}>
     {{form.as_div}}
     {% csrf_token %}
-    <input type="submit" class="button" value="Continue" alt='Contine' id="continue">
+    <input type="submit" class="button" value="Continue" alt='Continue' id="continue">
     <input type="hidden" value="{{ previous_url }}" id="url" name="url">
 </form>
 

--- a/application/views/feedback.py
+++ b/application/views/feedback.py
@@ -6,6 +6,7 @@ from django.core.mail import send_mail
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, reverse
 from django.conf import settings
+from urllib.parse import quote
 
 from ..notify import send_email
 from ..forms import FeedbackForm, FeedbackConfirmationForm
@@ -45,7 +46,7 @@ def feedback(request):
             template_id = '650b7c59-dd31-4876-869d-ea8bfd76063a'
             r = send_email(email, personalisation, template_id)
             print(r)
-            return HttpResponseRedirect(reverse('Feedback-Confirmation') + '?url=' + previous_url)
+            return HttpResponseRedirect(reverse('Feedback-Confirmation') + '?url=' + quote(previous_url))
 
         else:
             form.error_summary_title = 'There was a problem'

--- a/govuk_template/templates/govuk_template.html
+++ b/govuk_template/templates/govuk_template.html
@@ -75,7 +75,7 @@
         <div class="phase-banner-beta no-print">
           <p>
             <strong class="phase-tag">Beta</strong>
-            <span>{% block phase_banner_message %}<a href="{% url 'Feedback' %}?url={{ request.get_full_path }}" id="feedback">Tell us what you think</a> (takes 30 seconds){% endblock %}</span>
+            <span>{% block phase_banner_message %}<a href="{% url 'Feedback' %}?url={{ request.get_full_path|urlencode }}" id="feedback">Tell us what you think</a> (takes 30 seconds){% endblock %}</span>
           </p>
         </div>
       {% endif %}


### PR DESCRIPTION
## Description

Fix for bug where GET parameters for previous URLs were stripped off at the Feedback confirmation page, not allowing the user to navigate back to the page they were initially on.

## Todo's before PR

- [ ] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [ ] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
