### PR TITLE
CCN3-1577 bug fix: Reset email resent timestamp for flagged household member health checks

### DIFF
--- a/application/business_logic.py
+++ b/application/business_logic.py
@@ -673,6 +673,7 @@ def reset_declaration(application):
         application.change_declare = None
         application.save()
 
+
 def health_check_email_resend_logic(adult_record):
     """
     Method to verify if the last household member health check email can be sent, given a limit of 3 resends per 24
@@ -684,13 +685,13 @@ def health_check_email_resend_logic(adult_record):
     # If the last e-mail was sent within the last 24 hours
     if (datetime.now(pytz.utc) - adult_record.email_resent_timestamp) < timedelta(1):
 
-        # If the e-mail has been resent less than or equal to 3 times
-        if adult_record.email_resent <= 3:
+        # If the e-mail has been resent less than 3 times
+        if adult_record.email_resent < 3:
 
             return False
 
-        # If the email has been resent more than 3 times
-        elif adult_record.email_resent > 3:
+        # If the email has been resent more than or equal to 3 times
+        elif adult_record.email_resent >= 3:
 
             return True
 

--- a/application/views/other_people.py
+++ b/application/views/other_people.py
@@ -718,6 +718,11 @@ def other_people_summary(request):
             if adult.health_check_status != 'Done':
                 adult_health_check_status_list.append('To do')
 
+            # If the adult health check status is marked as flagged, set the email resend limit to 0
+            if adult.health_check_status == 'Flagged':
+                adult.email_resent = 0
+                adult.save()
+
             # Counter for table object to correctly set link in generic-error-summary template for flagged health check.
             table = Table([adult.pk])
             table.loop_counter = index + 1


### PR DESCRIPTION
## Description

Reset email resent timestamp to zero for flagged household member health checks

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
