### PR TITLE
fix/trello-81/household-email-not-sent

### DIFF
--- a/application/business_logic.py
+++ b/application/business_logic.py
@@ -682,26 +682,31 @@ def health_check_email_resend_logic(adult_record):
     :return: Boolean
     """
 
-    # If the last e-mail was sent within the last 24 hours
-    if (datetime.now(pytz.utc) - adult_record.email_resent_timestamp) < timedelta(1):
+    #If email_resent_timestamp is None then the email has never been resent.
+    if adult_record.email_resent_timestamp is not None:
 
-        # If the e-mail has been resent less than 3 times
-        if adult_record.email_resent < 3:
+        # If the last e-mail was sent within the last 24 hours
+        if (datetime.now(pytz.utc) - adult_record.email_resent_timestamp) < timedelta(1):
+
+            # If the e-mail has been resent less than 3 times
+            if adult_record.email_resent < 3:
+
+                return False
+
+            # If the email has been resent more than or equal to 3 times
+            elif adult_record.email_resent >= 3:
+
+                return True
+
+        # If the last e-mail to the household member has been sent more than 24 hours ago
+        elif (datetime.now(pytz.utc) - adult_record.email_resent_timestamp) > timedelta(1):
+            # Reset the email resent count
+            adult_record.email_resent = 0
+            adult_record.validated = False
+            adult_record.save()
 
             return False
-
-        # If the email has been resent more than or equal to 3 times
-        elif adult_record.email_resent >= 3:
-
-            return True
-
-    # If the last e-mail to the household member has been sent more than 24 hours ago
-    elif (datetime.now(pytz.utc) - adult_record.email_resent_timestamp) > timedelta(1):
-        # Reset the email resent count
-        adult_record.email_resent = 0
-        adult_record.validated = False
-        adult_record.save()
-
+    else:
         return False
 
 

--- a/application/business_logic.py
+++ b/application/business_logic.py
@@ -676,10 +676,10 @@ def reset_declaration(application):
 
 def health_check_email_resend_logic(adult_record):
     """
-    Method to verify if the last household member health check email can be sent, given a limit of 3 resends per 24
-    hours
+    Method to verify if the last household member health check email should not be sent, given a limit of 3 resends per 24
+    hours.
     :param: adult_record: An AdultInHome object
-    :return: Boolean
+    :return: Boolean: True if email cannot be sent, False if email can be sent.
     """
 
     #If email_resent_timestamp is None then the email has never been resent.

--- a/application/views/other_people.py
+++ b/application/views/other_people.py
@@ -1092,7 +1092,7 @@ def other_people_resend_confirmation(request):
 
         if adult_record.health_check_status == 'Flagged':
             status.update(application_id_local, 'people_in_home_status', 'WAITING')
-            adult_record.health_check_status = 'Started'
+            adult_record.health_check_status = 'To do'
             adult_record.save()
 
         variables = {


### PR DESCRIPTION
## Description

Fix for the infinite waiting status bug, as well as a fix for an bug with re-sending emails found on the journey.

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [x] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
