### PR TITLE
Add signatures to cookie content to prevent tampering

### DIFF
--- a/application/middleware.py
+++ b/application/middleware.py
@@ -6,9 +6,9 @@ OFS-MORE-CCN3: Apply to be a Childminder Beta
 
 from re import compile
 
-from django.conf import settings  # import the settings file
-from django.http import HttpResponseRedirect, HttpResponseServerError
-from django.shortcuts import reverse
+from django.conf import settings
+from django.http import HttpResponseRedirect
+from django.core.signing import Signer
 
 from .models import Application, UserDetails
 
@@ -82,11 +82,15 @@ class CustomAuthenticationHandler(object):
         if COOKIE_IDENTIFIER not in request.COOKIES:
             return None
         else:
-            return request.COOKIES.get(COOKIE_IDENTIFIER)
+            signer = Signer()
+            return signer.unsign(request.COOKIES.get(COOKIE_IDENTIFIER))
 
     @staticmethod
     def create_session(response, email):
-        response.set_cookie(COOKIE_IDENTIFIER, email, max_age=1800)
+        # Set value persisted in cookie with coupled signature to prevent cookie tampering
+        signer = Signer()
+        signed_email = signer.sign(email)
+        response.set_cookie(COOKIE_IDENTIFIER, signed_email, max_age=1800)
 
     @staticmethod
     def destroy_session(response):

--- a/childminder/settings/base.py
+++ b/childminder/settings/base.py
@@ -128,6 +128,7 @@ USE_TZ = True
 SECURE_BROWSER_XSS_FILTER = True
 CSRF_COOKIE_HTTPONLY = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
+SESSION_COOKIE_SECURE = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.11/howto/static-files/

--- a/childminder/settings/dev.py
+++ b/childminder/settings/dev.py
@@ -1,5 +1,4 @@
 import socket
-import os
 
 from .base import *
 
@@ -82,3 +81,40 @@ MIDDLEWARE = MIDDLEWARE + MIDDLEWARE_DEV
 INSTALLED_APPS = BUILTIN_APPS + THIRD_PARTY_APPS + DEV_APPS + PROJECT_APPS
 
 SECRET_KEY = '-asdasdsad322432maq#j23432*&(*&DASl6#mhak%8rbh$px8e&9c6b9@c7df=m'
+
+LOGGING = {
+  'version': 1,
+  'disable_existing_loggers': False,
+  'formatters': {
+    'console': {
+            # exact format is not important, this is the minimum information
+            'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        },
+        },
+  'handlers': {
+    'file': {
+        'level': 'DEBUG',
+        'class': 'logging.handlers.TimedRotatingFileHandler',
+        'filename': 'logs/output.log',
+        'formatter': 'console',
+        'when': 'midnight',
+        'backupCount': 10
+    },
+    'console': {
+        'level': 'DEBUG',
+        'class': 'logging.StreamHandler'
+    },
+   },
+   'loggers': {
+     '': {
+       'handlers': ['console'],
+         'level': 'DEBUG',
+           'propagate': True,
+      },
+      'django.server': {
+       'handlers': ['console'],
+         'level': 'INFO',
+           'propagate': True,
+      },
+    },
+}


### PR DESCRIPTION
## Description

Add logic to sign the inner content of cookies to prevent tampering. Previously if a user knew the UUID of an application, if the email address stored in a session cookie was adjusted to match the applicant's email, this would be allowed through.

Signatures have now been added to prevent tampering of cookie content.

## Todo's before PR

- [X] Branch has been rebased against develop
- [X] Unit tests passed (`make test`)
- [X] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [X] PR description describes the overall goals of PR commits
- [X] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [X] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
