### PR TITLE
fix/CCN3-1619/postcode-field-case-sensitive-when-resetting-password

### DIFF
--- a/application/forms/security_question.py
+++ b/application/forms/security_question.py
@@ -27,7 +27,7 @@ class SecurityQuestionForm(ChildminderForms):
         full_stop_stripper(self)
 
     def clean_security_answer(self):
-        security_answer = self.cleaned_data['security_answer']
+        security_answer = self.cleaned_data['security_answer'].upper()
         if self.answer.replace(' ', '') != security_answer.replace(' ', ''):
             raise forms.ValidationError('Your answer must match what you told us in your application')
 


### PR DESCRIPTION
## Description

Changes in security_question.py:

- Added .upper() to force uppercase for the security answer var, within the clean_security_answer function. 

Please note - There was no reset password involved, this bug could be replicated by signing back in, opening the received email and using the 'Don't have your phone?' option. When a lowercase postcode was entered it did not accept, even if the same as the one used in sign up. 

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
