### PR TITLE
CCN3-1561: Fix issue with People in the home task being set to Done

### DIFF
--- a/application/summary_page_data.py
+++ b/application/summary_page_data.py
@@ -52,7 +52,15 @@ personal_details_name_dict = collections.OrderedDict([('name', 'Your name'),
                                                        "Is this another childminder's home?"),
                                                       ('own_children', 'Do you have children of your own under 16?')])
 
-personal_details_link_dict = collections.OrderedDict([('name', 'Personal-Details-Name-View'),
+personal_details_link_dict_different_childcare_address = collections.OrderedDict([('name', 'Personal-Details-Name-View'),
+                                                      ('date_of_birth', 'Personal-Details-DOB-View'),
+                                                      ('home_address', 'Personal-Details-Home-Address-Manual-View'),
+                                                      ('childcare_address', 'Personal-Details-Childcare-Address-Manual-View'),
+                                                      ('working_in_other_childminder_home',
+                                                       'Personal-Details-Childcare-Address-Details-View'),
+                                                      ('own_children', 'Personal-Details-Your-Own-Children-View')])
+
+personal_details_link_dict_same_childcare_address = collections.OrderedDict([('name', 'Personal-Details-Name-View'),
                                                       ('date_of_birth', 'Personal-Details-DOB-View'),
                                                       ('home_address', 'Personal-Details-Home-Address-Manual-View'),
                                                       ('childcare_address', 'Personal-Details-Location-Of-Care-View'),

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -493,6 +493,14 @@ def personal_details_location_of_care(request):
 
             if home_address_record.childcare_address:
 
+                # Set Your children task status to Done
+                application.your_children_status = 'COMPLETED'
+
+                if Arc.objects.filter(application_id=app_id).count() > 0:
+                    arc = Arc.objects.get(application_id=app_id)
+                    arc.your_children_review = 'COMPLETED'
+                arc.save()
+
                 # Set working in other childminder home to false
                 application.working_in_other_childminder_home = False
                 application.date_updated = current_date

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -915,21 +915,23 @@ def personal_details_working_in_other_childminder_home(request):
 
             # Set People in your home task status to Completed when the applicant works in another childminder's home
             if application.working_in_other_childminder_home is True:
-                application.people_in_home_status = 'NOT_STARTED'
+                application.people_in_home_status = 'COMPLETED'
 
                 # Reset ARC status if there are comments
                 if Arc.objects.filter(application_id=app_id).count() > 0:
 
                     arc = Arc.objects.get(application_id=app_id)
 
-                    if arc.people_in_home_review != 'FLAGGED':
-                        arc.people_in_home_review = 'NOT_STARTED'
+                    arc.people_in_home_review = 'COMPLETED'
+                    arc.save()
             else:
-                application.people_in_home_status = 'COMPLETED'
+                application.people_in_home_status = 'NOT_STARTED'
 
                 if Arc.objects.filter(application_id=app_id).count() > 0:
                     arc = Arc.objects.get(application_id=app_id)
-                    arc.people_in_home_review = 'COMPLETED'
+                    if arc.people_in_home_review != 'FLAGGED':
+                        arc.people_in_home_review = 'NOT_STARTED'
+                        arc.save()
 
             application.date_updated = current_date
             application.save()

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -499,7 +499,7 @@ def personal_details_location_of_care(request):
                 if Arc.objects.filter(application_id=app_id).count() > 0:
                     arc = Arc.objects.get(application_id=app_id)
                     arc.your_children_review = 'COMPLETED'
-                arc.save()
+                    arc.save()
 
                 # Set working in other childminder home to false
                 application.working_in_other_childminder_home = False
@@ -1039,14 +1039,14 @@ def personal_details_own_children(request):
 
                     if arc.your_children_review != 'FLAGGED':
                         arc.your_children_review = 'NOT_STARTED'
-                    arc.save()
+                        arc.save()
             else:
                 application.your_children_status = 'COMPLETED'
 
                 if Arc.objects.filter(application_id=app_id).count() > 0:
                     arc = Arc.objects.get(application_id=app_id)
                     arc.your_children_review = 'COMPLETED'
-                arc.save()
+                    arc.save()
 
             application.date_updated = current_date
             application.save()

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -1031,12 +1031,14 @@ def personal_details_own_children(request):
 
                     if arc.your_children_review != 'FLAGGED':
                         arc.your_children_review = 'NOT_STARTED'
+                    arc.save()
             else:
                 application.your_children_status = 'COMPLETED'
 
                 if Arc.objects.filter(application_id=app_id).count() > 0:
                     arc = Arc.objects.get(application_id=app_id)
                     arc.your_children_review = 'COMPLETED'
+                arc.save()
 
             application.date_updated = current_date
             application.save()

--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -8,7 +8,8 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render, reverse
 
 from ..table_util import Table, create_tables, submit_link_setter
-from ..summary_page_data import personal_details_name_dict, personal_details_link_dict
+from ..summary_page_data import personal_details_name_dict, personal_details_link_dict_same_childcare_address,\
+    personal_details_link_dict_different_childcare_address
 from .. import address_helper, status
 from ..business_logic import (multiple_childcare_address_logic,
                               personal_dob_logic,
@@ -1154,7 +1155,15 @@ def personal_details_summary(request):
         })
 
         tables = [name_dob_dict, address_dict, own_children_dict]
-        table_list = create_tables(tables, personal_details_name_dict, personal_details_link_dict)
+
+        # Set change link for childcare address according to whether the childcare address is the same as the home
+        # address
+        if location_of_childcare:
+            table_list = create_tables(tables, personal_details_name_dict,
+                                       personal_details_link_dict_same_childcare_address)
+        else:
+            table_list = create_tables(tables, personal_details_name_dict,
+                                       personal_details_link_dict_different_childcare_address)
 
         form = PersonalDetailsSummaryForm()
         application = Application.get_id(app_id=app_id)


### PR DESCRIPTION
## Description

- Fix bug where the People in home task is being set to Done without it having been completed
- Update change link logic for childcare address summary row: this goes to the childcare location page when the childcare address is the same as the home address, otherwise it goes to the manual childcare address page

## Todo's before PR

- [x] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
