### PR TITLE
Add revised logic for children address details

### DIFF
--- a/application/tests/tests_application/test_your_children.py
+++ b/application/tests/tests_application/test_your_children.py
@@ -479,6 +479,7 @@ class YourChildrenTests(TestCase, ApplicationTestBase):
 
     @tag('http')
     def test_if_all_children_living_with_childminder_redirected_to_summary(self):
+        self.TestAppPersonalDetailsHomeAddress()
         self.__submit_test_children_details()
 
         response = self.client.post(
@@ -511,6 +512,7 @@ class YourChildrenTests(TestCase, ApplicationTestBase):
 
     @tag('http')
     def test_asked_for_second_child_address_if_living_with_first_children(self):
+        self.TestAppPersonalDetailsHomeAddress()
         self.__submit_test_children_details()
 
         response = self.client.post(

--- a/application/views/your_children.py
+++ b/application/views/your_children.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 
 from ..forms import YourChildrenGuidanceForm, YourChildrenDetailsForm, YourChildrenLivingWithYouForm, ChildAddressForm, \
     YourChildrenSummaryForm, YourChildrenAddressLookupForm, YourChildManualAddressForm, ArcComments
-from ..models import Application, Child, ChildAddress
+from ..models import Application, Child, ChildAddress, ApplicantPersonalDetails, ApplicantHomeAddress
 from .. import status, address_helper
 from ..business_logic import remove_child, rearrange_children, your_children_details_logic, reset_declaration, \
     child_address_logic
@@ -573,10 +573,7 @@ def __your_children_living_with_you_post_handler(request):
         # If post submission marks the child as residing with the childminder, delete any previously attributed
         # address details for data cleanliness purposes. Likewise, remove any ARC comments
         if child.lives_with_childminder:
-            if ChildAddress.objects.filter(application_id=application_id, child=child.child).exists():
-                child_address_record = ChildAddress.objects.get(application_id=application_id, child=child.child)
-                __remove_arc_address_flag(child_address_record)
-                child_address_record.delete()
+            __set_child_address_to_childminder_personal_address(application_id, child)
 
         child.save()
 
@@ -588,6 +585,36 @@ def __your_children_living_with_you_post_handler(request):
     else:
         return HttpResponseRedirect(reverse('Your-Children-Summary-View') + '?id=' +
                                     application_id)
+
+
+def __set_child_address_to_childminder_personal_address(application_id, child):
+    application = Application.objects.get(application_id=application_id)
+
+    child_address_record = ChildAddress(
+        application_id=application
+    )
+
+    if ChildAddress.objects.filter(application_id=application_id, child=child.child).exists():
+        child_address_record = ChildAddress.objects.get(application_id=application_id, child=child.child)
+
+        __remove_arc_address_flag(child_address_record)
+
+    # Set child address to the personal details of the applicant
+    applicant = ApplicantPersonalDetails.get_id(app_id=application_id)
+    applicant_personal_address = \
+        ApplicantHomeAddress.objects.get(personal_detail_id=applicant,
+                                         current_address=True)
+
+    child_address_record.child = child.child
+    child_address_record.street_line1 = applicant_personal_address.street_line1
+    child_address_record.street_line2 = applicant_personal_address.street_line2
+    child_address_record.town = applicant_personal_address.town
+    child_address_record.county = applicant_personal_address.county
+    child_address_record.country = applicant_personal_address.country
+    child_address_record.postcode = applicant_personal_address.postcode
+
+    child_address_record.save()
+
 
 
 def your_children_address_capture(request):


### PR DESCRIPTION
## Description

An update to permit flagging of an individual child address in the ARC view. If a child lives with an applicant their address is now stored as the childminder's address which allows an ARC user to flag that specific field.

## Todo's before PR

- [X] Branch has been rebased against develop
- [X] Unit tests passed (`make test`)
- [X] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [X] PR description describes the overall goals of PR commits
- [X] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
