### PR TITLE
CCN3-1883: Updating content for validation messages and error messages on declaration for household members

### DIFF
--- a/application/forms/PITH_forms/PITH_declaration_form.py
+++ b/application/forms/PITH_forms/PITH_declaration_form.py
@@ -8,11 +8,12 @@ class PITHDeclarationForm(ChildminderForms):
     """
     field_label_classes = 'form-label-bold'
     error_summary_template_name = 'standard-error-summary.html'
+    error_summary_title = 'There was a problem'
     auto_replace_widgets = True
 
     declaration_confirmation = forms.BooleanField(label='I confirm', required=True,
                                                   error_messages={
-                                                      'required': 'You must confirm everything on this page to continue'})
+                                                      'required': 'You must confirm that the information you have given is correct'})
 
     def clean_declaration_confirmation(self):
         """
@@ -21,5 +22,5 @@ class PITHDeclarationForm(ChildminderForms):
         """
         declaration_confirmation = self.cleaned_data['declaration_confirmation']
         if not declaration_confirmation:
-            raise forms.ValidationError('You must confirm everything on this page to continue')
+            raise forms.ValidationError('You must confirm that the information you have given is correct')
         return declaration_confirmation


### PR DESCRIPTION
## Description

[Goes here]

## Todo's before PR

- [x] Branch has been rebased against develop
- [x] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## Migrations

- [] Null fields in models specifies default value
- [] You generated and applied migrations (`make migrate`)
- [] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [x] Code syntax formatting checked
- [x] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
