### PR TITLE
fix/trello-116/your-children-personal-details-flagging

### DIFF
--- a/application/views/personal_details.py
+++ b/application/views/personal_details.py
@@ -30,6 +30,7 @@ from ..forms import (PersonalDetailsChildcareAddressForm,
                      PersonalDetailsWorkingInOtherChildminderHomeForm)
 from ..models import (ApplicantHomeAddress,
                       ApplicantName,
+                      ArcComments,
                       ApplicantPersonalDetails,
                       Application,
                       Arc)
@@ -1174,7 +1175,10 @@ def personal_details_summary(request):
 
         tables = [name_dob_dict, address_dict]
 
-        if not location_of_childcare:
+        own_children_arc = ArcComments.objects.get(table_pk=app_id, field_name='own_children')
+
+        # If the own_children task if flagged, or if the answer is changed, add the table
+        if own_children_arc.flagged or not location_of_childcare or application.own_children:
             tables.append(own_children_dict)
 
         # Set change link for childcare address according to whether the childcare address is the same as the home


### PR DESCRIPTION
## Description

Added extra logic to decide when the your children task is shown on the personal details summary page
Your children will now show if:
* It has been flagged in ARC
* The applicant has changed their answer from 'No' to 'Yes'
* The applicant does not work in their own home, and must have answered the question.


## Todo's before PR

- [x] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [x] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [x] PR description describes the overall goals of PR commits
- [x] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [x] Specified reviewers (even if it's yourself)
- [x] Specified assignees (those who'll merge)
- [x] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [x] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
