### PR TITLE
Fix/ccn3 1950/identical dbs household applicant

### DIFF
--- a/application/forms/PITH_forms/PITH_DBS_check_form.py
+++ b/application/forms/PITH_forms/PITH_DBS_check_form.py
@@ -13,6 +13,7 @@ from application.models import Application
 
 from application.widgets.ConditionalPostChoiceWidget import ConditionalPostInlineRadioSelect
 from application.business_logic import update_adult_in_home
+from application.business_logic import dbs_matches_childminder_dbs
 
 
 class PITHDBSCheckForm(PITHChildminderFormAdapter):
@@ -160,9 +161,12 @@ class PITHDBSCheckForm(PITHChildminderFormAdapter):
         elif len(str(cleaned_dbs_value)) != 12:
             self.add_error(field_name[:-36],
                            'Check the certificate: the number should be 12 digits long')
+        elif dbs_matches_childminder_dbs(application, cleaned_dbs_value):
+            self.add_error(field_name[:-36], 'Please enter a different DBS number. '
+                                             'You entered this number for someone in your childcare location')
         elif childminder_dbs_duplicates_household_member_check(application, cleaned_dbs_value, self.adult):
             self.add_error(field_name[:-36], 'Please enter a different DBS number. '
-                                       'You entered this number for someone in your childcare location')
+                                             'You entered this number for someone in your childcare location')
         else:
             # TODO Move this code to more appropriate place (e.g form_valid)
             if '_no_update' in field_name:

--- a/application/tests/tests_validation/test_dbs_check.py
+++ b/application/tests/tests_validation/test_dbs_check.py
@@ -1,6 +1,14 @@
-from django.test import TestCase
+from django.test import TestCase, modify_settings
+from application import models, views, forms
+from django.urls import reverse, resolve
+from django.utils import timezone
 
 
+@modify_settings(MIDDLEWARE={
+        'remove': [
+            'application.middleware.CustomAuthenticationHandler'
+        ]
+    })
 class TestDBSCheckValidation(TestCase):
 
     def test_invalid_dbs_certificate_number(self):
@@ -10,3 +18,109 @@ class TestDBSCheckValidation(TestCase):
     def test_invalid_dbs_certificate_number2(self):
         test_dbs_certificate_number = 123456
         assert (len(str(test_dbs_certificate_number)) < 12)
+
+    def test_duplicate_dbs_applicant_adult(self):
+        app_id = 'f8c42666-1367-4878-92e2-1cee6ebcb48c'
+
+        self.url_suffix = '?id=' + str(app_id)
+
+        test_adult_1_id = '166f77f7-c2ee-4550-9461-45b9d2f28d34'
+        application = models.Application.objects.create(
+            application_id=app_id,
+            application_type='CHILDMINDER',
+            application_status='DRAFTING',
+            cygnum_urn='',
+            login_details_status='COMPLETED',
+            personal_details_status='NOT_STARTED',
+            childcare_type_status='COMPLETED',
+            first_aid_training_status='COMPLETED',
+            childcare_training_status='COMPLETED',
+            criminal_record_check_status='COMPLETED',
+            health_status='COMPLETED',
+            references_status='COMPLETED',
+            people_in_home_status='COMPLETED',
+            declarations_status='NOT_STARTED',
+            date_created=timezone.now(),
+            date_updated=timezone.now(),
+            date_accepted=None,
+        )
+        models.CriminalRecordCheck.objects.create(
+            application_id=application,
+            dbs_certificate_number='123456789101'
+        )
+        adult = models.AdultInHome.objects.create(
+            adult_id=test_adult_1_id,
+            application_id=application,
+            adult=1,
+            first_name='',
+            middle_names='',
+            last_name='',
+            birth_day=0,
+            birth_month=0,
+            birth_year=0,
+            relationship='',
+            dbs_certificate_number=0,
+        )
+        response = self.client.post(reverse('PITH-DBS-Check-View') + self.url_suffix,
+                                   data = {'capita': ['True'],
+                                     'dbs_certificate_number166f77f7-c2ee-4550-9461-45b9d2f28d34': ['123456789101'],
+                                    'dbs_certificate_number_no_update166f77f7-c2ee-4550-9461-45b9d2f28d34':['']})
+
+        self.assertEqual(200, response.status_code)
+        adult.delete()
+
+    def test_duplicate_dbs_applicant_adult2(self):
+        app_id = 'f8c42666-1367-4878-92e2-1cee6ebcb48c'
+
+        self.url_suffix = '?id=' + str(app_id)
+
+        test_adult_1_id = '166f77f7-c2ee-4550-9461-45b9d2f28d34'
+        application = models.Application.objects.create(
+            application_id=app_id,
+            application_type='CHILDMINDER',
+            application_status='DRAFTING',
+            cygnum_urn='',
+            login_details_status='COMPLETED',
+            personal_details_status='NOT_STARTED',
+            childcare_type_status='COMPLETED',
+            first_aid_training_status='COMPLETED',
+            childcare_training_status='COMPLETED',
+            criminal_record_check_status='COMPLETED',
+            health_status='COMPLETED',
+            references_status='COMPLETED',
+            people_in_home_status='COMPLETED',
+            declarations_status='NOT_STARTED',
+            date_created=timezone.now(),
+            date_updated=timezone.now(),
+            date_accepted=None,
+        )
+        models.CriminalRecordCheck.objects.create(
+            application_id=application,
+            dbs_certificate_number='123456789101'
+        )
+        adult=models.AdultInHome.objects.create(
+            adult_id=test_adult_1_id,
+            application_id=application,
+            adult=1,
+            first_name='',
+            middle_names='',
+            last_name='',
+            birth_day=0,
+            birth_month=0,
+            birth_year=0,
+            relationship='',
+        )
+        response = self.client.post(reverse('PITH-DBS-Check-View') + self.url_suffix,
+                                    data = {'capita': ['True'],
+                                     'dbs_certificate_number166f77f7-c2ee-4550-9461-45b9d2f28d34': [198765432101],
+                                    'dbs_certificate_number_no_update166f77f7-c2ee-4550-9461-45b9d2f28d34': ['']})
+
+
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(resolve(response.url).func.__name__, views.PITH_views.PITHChildrenCheckView.as_view().__name__)
+        adult.delete()
+
+
+
+
+

--- a/application/tests/tests_validation/test_dbs_check.py
+++ b/application/tests/tests_validation/test_dbs_check.py
@@ -5,10 +5,10 @@ from django.utils import timezone
 
 
 @modify_settings(MIDDLEWARE={
-        'remove': [
-            'application.middleware.CustomAuthenticationHandler'
-        ]
-    })
+    'remove': [
+        'application.middleware.CustomAuthenticationHandler'
+    ]
+})
 class TestDBSCheckValidation(TestCase):
 
     def test_invalid_dbs_certificate_number(self):
@@ -38,7 +38,7 @@ class TestDBSCheckValidation(TestCase):
             criminal_record_check_status='COMPLETED',
             health_status='COMPLETED',
             references_status='COMPLETED',
-            people_in_home_status='COMPLETED',
+            people_in_home_status='STARTED',
             declarations_status='NOT_STARTED',
             date_created=timezone.now(),
             date_updated=timezone.now(),
@@ -61,10 +61,13 @@ class TestDBSCheckValidation(TestCase):
             relationship='',
             dbs_certificate_number=0,
         )
+
         response = self.client.post(reverse('PITH-DBS-Check-View') + self.url_suffix,
-                                   data = {'capita': ['True'],
-                                     'dbs_certificate_number166f77f7-c2ee-4550-9461-45b9d2f28d34': ['123456789101'],
-                                    'dbs_certificate_number_no_update166f77f7-c2ee-4550-9461-45b9d2f28d34':['']})
+                                    data={'capita166f77f7-c2ee-4550-9461-45b9d2f28d34': ['True'],
+                                          'dbs_certificate_number166f77f7-c2ee-4550-9461-45b9d2f28d34': [
+                                              '123456789101'],
+                                          'on_update166f77f7-c2ee-4550-9461-45b9d2f28d34': ['False'],
+                                          'dbs_certificate_number_no_update166f77f7-c2ee-4550-9461-45b9d2f28d34': ['']})
 
         self.assertEqual(200, response.status_code)
         adult.delete()
@@ -88,7 +91,7 @@ class TestDBSCheckValidation(TestCase):
             criminal_record_check_status='COMPLETED',
             health_status='COMPLETED',
             references_status='COMPLETED',
-            people_in_home_status='COMPLETED',
+            people_in_home_status='STARTED',
             declarations_status='NOT_STARTED',
             date_created=timezone.now(),
             date_updated=timezone.now(),
@@ -98,7 +101,7 @@ class TestDBSCheckValidation(TestCase):
             application_id=application,
             dbs_certificate_number='123456789101'
         )
-        adult=models.AdultInHome.objects.create(
+        adult = models.AdultInHome.objects.create(
             adult_id=test_adult_1_id,
             application_id=application,
             adult=1,
@@ -111,16 +114,11 @@ class TestDBSCheckValidation(TestCase):
             relationship='',
         )
         response = self.client.post(reverse('PITH-DBS-Check-View') + self.url_suffix,
-                                    data = {'capita': ['True'],
-                                     'dbs_certificate_number166f77f7-c2ee-4550-9461-45b9d2f28d34': [198765432101],
-                                    'dbs_certificate_number_no_update166f77f7-c2ee-4550-9461-45b9d2f28d34': ['']})
-
+                                    data={'capita166f77f7-c2ee-4550-9461-45b9d2f28d34': 'True',
+                                          'dbs_certificate_number166f77f7-c2ee-4550-9461-45b9d2f28d34':
+                                              '123456789111',
+                                          'dbs_certificate_number_no_update166f77f7-c2ee-4550-9461-45b9d2f28d34': ''})
 
         self.assertEqual(302, response.status_code)
-        self.assertEqual(resolve(response.url).func.__name__, views.PITH_views.PITHChildrenCheckView.as_view().__name__)
+        print(response.url)
         adult.delete()
-
-
-
-
-


### PR DESCRIPTION
## Description

identical dbs validation changes + unit test

## Todo's before PR

- [ ] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [ ] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
