### PR TITLE
fix adults dbs type page not listing adults after going back

### DIFF
--- a/application/tests/test_people_in_the_home/test_routing.py
+++ b/application/tests/test_people_in_the_home/test_routing.py
@@ -140,6 +140,7 @@ class PITHAdultDetailsFunctionalTests(PITHFunctionalTestCase):
     def test_post_to_MOD_checks_page_redirects_to_dbs_checks_page(self):
         self.skipTest('testNotImplemented')
 
+
 mock_dbs_read = Mock()
 
 
@@ -360,6 +361,42 @@ class PITHAdultDBSFunctionalTests(PITHFunctionalTestCase):
                           .format(id=adult2.pk))
         utils.assertXPath(response, "//input[@type='radio' and (@name='enhanced_check{id}' or @name='on_update{id}')]"
                           .format(id=adult3.pk))
+
+    def test_type_of_check_page_renders_adult_forms_again_when_returning_to_change_answers(self):
+
+        adult1 = self.make_adult(dbs_number='123456789013', dbs_saved_yet=True, record_found=False,
+                                 enhanced_answer=True, on_update_answer=False)
+        adult2 = self.make_adult(dbs_number='123456789014', dbs_saved_yet=True, record_found=True, issue_recent=False,
+                                 on_update_answer=True)
+
+        response = self.client.get(reverse('PITH-DBS-Type-Of-Check-View'), data={'id': self.app_id})
+
+        self.assertEqual(response.status_code, 200)
+        utils.assertView(response, PITH_views.PITHDBSTypeOfCheckView)
+
+        utils.assertXPath(response, "//input[@type='radio' and @name='enhanced_check{id}']".format(id=adult1.pk))
+        utils.assertXPath(response, "//input[@type='radio' and @name='on_update{id}']".format(id=adult1.pk))
+        utils.assertNotXPath(response, "//input[@type='radio' and @name='enhanced_check{id}']".format(id=adult2.pk))
+        utils.assertXPath(response, "//input[@type='radio' and @name='on_update{id}']".format(id=adult2.pk))
+
+    def test_rendering_type_of_check_page_doesnt_remove_previous_answers_from_database(self):
+
+        adult1 = self.make_adult(dbs_number='123456789013', dbs_saved_yet=True, record_found=False,
+                                 enhanced_answer=True, on_update_answer=False)
+        adult2 = self.make_adult(dbs_number='123456789014', dbs_saved_yet=True, record_found=True, issue_recent=False,
+                                 on_update_answer=True)
+
+        response = self.client.get(reverse('PITH-DBS-Type-Of-Check-View'), data={'id': self.app_id})
+
+        self.assertEqual(response.status_code, 200)
+
+        refetched_adult1 = models.AdultInHome.objects.get(pk=adult1.pk)
+        self.assertEqual(True, refetched_adult1.enhanced_check)
+        self.assertEqual(False, refetched_adult1.on_update)
+
+        refetched_adult2 = models.AdultInHome.objects.get(pk=adult2.pk)
+        self.assertIsNone(refetched_adult2.enhanced_check)
+        self.assertEqual(True, refetched_adult2.on_update)
 
     def test_any_invalid_responses_on_type_of_check_page_returns_to_type_of_check_page(self):
 

--- a/application/views/PITH_views/PITH_DBS_type_of_check.py
+++ b/application/views/PITH_views/PITH_DBS_type_of_check.py
@@ -97,7 +97,7 @@ class PITHDBSTypeOfCheckView(PITHMultiRadioView):
 
     def get_adults_needing_info(self, application_id):
         """
-        Finds the list of adults in the home for this application for whom we need more
+        Finds the list of adults in the home for this application for whom we need (or did need) more
             info about their dbs number
         :param application_id:
         :return: list of 2-tuples each containing the adult model and their DBSStatus
@@ -105,6 +105,10 @@ class PITHDBSTypeOfCheckView(PITHMultiRadioView):
 
         filtered = []
         for adult in AdultInHome.objects.filter(application_id=application_id):
+
+            # pretend they haven't answered yet, in case user is returning to change their answers
+            adult.enhanced_check = None
+            adult.on_update = None
 
             dbs_status = find_dbs_status(adult, adult)
 


### PR DESCRIPTION
## Description

Type of Check page for Adults in the Home wasn't showing enhanced-check and on-update radios again when returning to the page via the back link.

## Todo's before PR

- [ ] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [ ] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
