### PR TITLE
allow adult in home address to be null in summaries

### DIFF
--- a/application/views/PITH_views/PITH_check_your_answers.py
+++ b/application/views/PITH_views/PITH_check_your_answers.py
@@ -182,7 +182,7 @@ class PITHCheckYourAnswersView(PITHTemplateView):
             name = ' '.join([adult.first_name, (adult.middle_names or ''), adult.last_name])
             birth_date = ' '.join([str(adult.birth_day), calendar.month_name[adult.birth_month], str(adult.birth_year)])
 
-            if not adult.PITH_same_address:
+            if adult.PITH_same_address is not None and not adult.PITH_same_address:
                 adult_in_home_address = AdultInHomeAddress.objects.get(application_id=app_id, adult_id=adult.pk)
                 adult_address_string = ' '.join([adult_in_home_address.street_line1,
                                                  adult_in_home_address.street_line2 or '',
@@ -201,8 +201,6 @@ class PITHCheckYourAnswersView(PITHTemplateView):
                 ('email', adult.email),
                 ('PITH_mobile_number', adult.PITH_mobile_number),
                 ('PITH_same_address', adult_address_string),
-                ('PITH_moved_in', AdultInHomeAddress.objects.get(application_id=app_id,
-                                                                 adult_id=adult.pk).get_moved_in_date()),
                 ('lived_abroad', adult.lived_abroad),
             ]
 
@@ -219,11 +217,6 @@ class PITHCheckYourAnswersView(PITHTemplateView):
 
             if adult.on_update is not None:
                 base_adult_fields.append(('on_update', adult.on_update))
-
-            if AdultInHomeAddress.objects.get(application_id=app_id,
-                                           adult_id=adult.pk).get_moved_in_date() is not None:
-                base_adult_fields.append(('PITH_moved_in', AdultInHomeAddress.objects.get(application_id=app_id,
-                                                                 adult_id=adult.pk).get_moved_in_date()))
 
             if application.people_in_home_status == 'IN_PROGRESS' and any(
                     [adult.email_resent_timestamp is None for adult in adults_list]):

--- a/application/views/PITH_views/PITH_check_your_answers.py
+++ b/application/views/PITH_views/PITH_check_your_answers.py
@@ -201,6 +201,8 @@ class PITHCheckYourAnswersView(PITHTemplateView):
                 ('email', adult.email),
                 ('PITH_mobile_number', adult.PITH_mobile_number),
                 ('PITH_same_address', adult_address_string),
+                ('PITH_moved_in', AdultInHomeAddress.objects.get(application_id=app_id,
+                                                                 adult_id=adult.pk).get_moved_in_date()),
                 ('lived_abroad', adult.lived_abroad),
             ]
 
@@ -218,6 +220,11 @@ class PITHCheckYourAnswersView(PITHTemplateView):
             if adult.on_update is not None:
                 base_adult_fields.append(('on_update', adult.on_update))
 
+            if AdultInHomeAddress.objects.get(application_id=app_id,
+                                              adult_id=adult.pk).get_moved_in_date() is not None:
+                base_adult_fields.append(('PITH_moved_in', AdultInHomeAddress.objects.get(application_id=app_id,
+                                                                                          adult_id=adult.pk).get_moved_in_date()))
+                
             if application.people_in_home_status == 'IN_PROGRESS' and any(
                     [adult.email_resent_timestamp is None for adult in adults_list]):
                 adult_fields = collections.OrderedDict(base_adult_fields)

--- a/application/views/declaration.py
+++ b/application/views/declaration.py
@@ -181,19 +181,26 @@ def declaration_summary(request, print_mode=False):
         if adults_list_exists:
             adults_list = AdultInHome.objects.filter(application_id=application_id_local).order_by('adult')
             for adult in adults_list:
-                adult_in_home_address = AdultInHomeAddress.objects.get(application_id=application_id_local,
+                if adult.PITH_same_address is not None:
+                    adult_in_home_address = AdultInHomeAddress.objects.get(application_id=application_id_local,
                                                                        adult_id=adult.pk)
-                # For each adult, append the correct attribute (e.g. name, relationship) to the relevant list
-                # Concatenate the adult's name for display, displaying any middle names if present
+                    # For each adult, append the correct attribute (e.g. name, relationship) to the relevant list
+                    # Concatenate the adult's name for display, displaying any middle names if present
 
-                if not adult.PITH_same_address:
-                    adult_address_string = ' '.join([adult_in_home_address.street_line1,
+                    if not adult.PITH_same_address:
+                        adult_address_string = ' '.join([adult_in_home_address.street_line1,
                                                      adult_in_home_address.street_line2 or '',
                                                      adult_in_home_address.town, adult_in_home_address.county or '',
                                                      adult_in_home_address.postcode])
 
+                    else:
+                        adult_address_string = 'Same as home address'
+
+                    if adult_in_home_address.moved_in_year is not None:
+                        adult_PITH_moved_in_list.append(adult_in_home_address.get_moved_in_date())
+                        
                 else:
-                    adult_address_string = 'Same as home address'
+                    adult_address_string = ''
 
                 if adult.middle_names != '':
                     name = adult.first_name + ' ' + adult.middle_names + ' ' + adult.last_name
@@ -209,9 +216,6 @@ def declaration_summary(request, print_mode=False):
                     adult_birth_month = '0' + str(adult.birth_month)
                 else:
                     adult_birth_month = str(adult.birth_month)
-
-                if adult_in_home_address.moved_in_year is not None:
-                    adult_PITH_moved_in_list.append(adult_in_home_address.get_moved_in_date())
 
                 adult_title_list.append(adult.title)
                 adult_name_list.append(name)


### PR DESCRIPTION
## Description

handle situation where adult in home address is not entered (if it's a draft application from before the deployment) 

## Todo's before PR

- [ ] Branch has been rebased against develop
- [ ] Unit tests passed (`make test`)
- [ ] PR named appropriately - see [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Commits-guideline)
- [ ] PR description describes the overall goals of PR commits
- [ ] Templates have been checked against the relevant user-story

## Migrations

- [ ] Null fields in models specifies default value
- [ ] You generated and applied migrations (`make migrate`)
- [ ] You updated fixtures (`make export`)

## PR Todo's

Please refer to PR [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-submit-a-pull-request)

- [ ] Specified reviewers (even if it's yourself)
- [ ] Specified assignees (those who'll merge)
- [ ] Specified labels

## PR review

Please refer to PR review [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-review-a-pull_request)

- [ ] Code syntax formatting checked
- [ ] Debug messages are absent

## PR merge

Select only one:

- [ ] Should be merged?
- [ ] Should be rebased?
- [ ] Should be squashed?

Please refer to PR merge [guide](https://github.com/InformedSolutions/OFS-MORE-DevOps-Tooling/wiki/Pull-requests#how-to-merge-a-pull_request)
